### PR TITLE
add 7d as range option

### DIFF
--- a/yahooquery/base.py
+++ b/yahooquery/base.py
@@ -285,7 +285,7 @@ class _YahooFinance(object):
                     '1d', '5d', '1wk', '1mo', '3mo'
                 ]},
                 'range': {'required': False, 'default': None, 'options': [
-                    '1d', '5d', '1mo', '3mo',
+                    '1d', '5d', '7d', '1mo', '3mo',
                     '6mo', '1y', '2y', '5y',
                     '10y', 'ytd', 'max'
                 ]},


### PR DESCRIPTION
Yahoo's API accepts 7d as maximum range for 1 minute intraday, however, because this option is not available in `_CONFIG['chart']['range']`, the max one can get at a time is 5 days, I believe a 7d option should be included.
