### PR TITLE
add 60d as range option and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ aapl.history(period='max')
 aapl.history(start='2019-05-01')  # Default end date is now
 aapl.history(end='2018-12-31')  # Default start date is 1900-01-01
 
-# Period options = 1d, 5d, 1mo, 3mo, 6mo, 1y, 2y, 5y, 10y, ytd, max
+# Period options = 1d, 5d, 7d, 60d, 1mo, 3mo, 6mo, 1y, 2y, 5y, 10y, ytd, max
 # Interval options = 1m, 2m, 5m, 15m, 30m, 60m, 90m, 1h, 1d, 5d, 1wk, 1mo, 3mo
 ```
 

--- a/yahooquery/base.py
+++ b/yahooquery/base.py
@@ -285,7 +285,7 @@ class _YahooFinance(object):
                     '1d', '5d', '1wk', '1mo', '3mo'
                 ]},
                 'range': {'required': False, 'default': None, 'options': [
-                    '1d', '5d', '7d', '1mo', '3mo',
+                    '1d', '5d', '7d', '60d', '1mo', '3mo',
                     '6mo', '1y', '2y', '5y',
                     '10y', 'ytd', 'max'
                 ]},


### PR DESCRIPTION
This is similar to https://github.com/dpguthrie/yahooquery/pull/13, but it adds 60d as an option for the period parameter. Also, updates the readme file for the new parameters.

interval | maximum period range
-- | --
1m | 7d 
2m | 35~d
5m, etc. | 60d 

Even though the maximum period range for '2m' is about 35~ business days, using '60d' as a parameter will fetch as many days as possible. I did some experiments on [this notebook](https://colab.research.google.com/drive/1HegnVR_NmDvhKw4f5TvdFEbOBeL2P3kx#scrollTo=qabmeHTGYwaf).

The PR is intended to solve https://github.com/dpguthrie/yahooquery/issues/21