### PR TITLE
Update lxml to 4.5.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 INSTALL_REQUIRES = [
-    "lxml==4.5.0",
+    "lxml==4.5.2",
     "pandas>=0.24",
     "requests-futures==1.0.0",
     "selenium==3.141.0",


### PR DESCRIPTION
I couldn't install yahooquery on Python 3.9 because of lxml, so I updated it to a slightly newer version and it worked fine here