### PR TITLE
Update available screeners

### DIFF
--- a/yahooquery/utils/screeners.py
+++ b/yahooquery/utils/screeners.py
@@ -1,1627 +1,1917 @@
 SCREENERS = {
-    "accident_health_insurance": {
-        "desc": "Accident & Health Insurance Stocks",
-        "id": "ae93c45e-368f-4892-8684-f3503d7b7086",
-        "title": "Accident & Health Insurance",
-    },
-    "advertising_agencies": {
-        "desc": "Advertising Agencies Stocks",
-        "id": "7deebcc3-2f08-489d-ac7b-0655da297013",
-        "title": "Advertising Agencies",
-    },
-    "aerospace_defense_major_diversified": {
-        "desc": "Aerospace/Defense - Major Diversified Stocks",
-        "id": "5f82626f-0c7e-4197-8911-04674b56d415",
-        "title": "Aerospace/Defense - Major Diversified",
-    },
-    "aerospace_defense_products_services": {
-        "desc": "Aerospace/Defense Products & Services Stocks",
-        "id": "19535808-f950-4791-978d-81a916513df2",
-        "title": "Aerospace/Defense Products & Services",
-    },
-    "aggressive_small_caps": {
-        "desc": "Small cap stocks with high earnings growth rates",
-        "id": "af57f75b-eb22-4565-a604-5eb8744dd35c",
-        "title": "Aggresive small cap stocks",
-    },
-    "agricultural_chemicals": {
-        "desc": "Agricultural Chemicals Stocks",
-        "id": "8ed42a44-1d08-4c7c-b197-884b5350d263",
-        "title": "Agricultural Chemicals",
-    },
-    "air_delivery_freight_services": {
-        "desc": "Air Delivery & Freight Services Stocks",
-        "id": "9d07b316-fbea-4fa3-a293-4bc00fe55a71",
-        "title": "Air Delivery & Freight Services",
-    },
-    "air_services_other": {
-        "desc": "Air Services, Other Stocks",
-        "id": "0941052b-864a-41e9-8aac-37adf7561659",
-        "title": "Air Services, Other",
-    },
-    "all_cryptocurrencies_au": {
-        "desc": "Cryptocurrencies ordered in descending order by intraday marketcap",
-        "id": "d4146c38-dd86-418c-b043-82858b3c472d",
-        "title": "All Cryptocurrencies",
-    },
-    "all_cryptocurrencies_ca": {
-        "desc": "Cryptocurrencies ordered in descending order by intraday marketcap",
-        "id": "7d701aca-d272-4d62-8921-fbdf3a5e90cd",
-        "title": "All Cryptocurrencies",
-    },
-    "all_cryptocurrencies_eu": {
-        "desc": "Cryptocurrencies ordered in descending order by intraday marketcap",
-        "id": "56d93251-dc99-492c-b7a9-4335a103c788",
-        "title": "All Cryptocurrencies",
-    },
-    "all_cryptocurrencies_gb": {
-        "desc": "Cryptocurrencies ordered in descending order by intraday marketcap",
-        "id": "b4ee2223-1076-4666-9348-76ec467e6f05",
-        "title": "All Cryptocurrencies",
-    },
-    "all_cryptocurrencies_in": {
-        "desc": "Cryptocurrencies ordered in descending order by intraday marketcap",
-        "id": "ab1f1b1f-e355-49e2-b316-341db363f627",
-        "title": "All Cryptocurrencies",
-    },
-    "all_cryptocurrencies_us": {
-        "desc": "Cryptocurrencies ordered in descending order by intraday marketcap",
-        "id": "80046292-2898-474e-841c-7866e4f2fc80",
-        "title": "All Cryptocurrencies",
-    },
-    "aluminum": {
-        "desc": "Aluminum Stocks",
-        "id": "6048eee9-dfe4-42e2-804e-7814644078fe",
-        "title": "Aluminum",
-    },
-    "apparel_stores": {
-        "desc": "Apparel Stores Stocks",
-        "id": "f2f6b0d6-24aa-4418-8a1c-878089899367",
-        "title": "Apparel Stores",
-    },
-    "appliances": {
-        "desc": "Appliances Stocks",
-        "id": "324a26f1-d9d1-4f1d-a111-75e709b9cb8d",
-        "title": "Appliances",
-    },
-    "application_software": {
-        "desc": "Application Software Stocks",
-        "id": "2ba474b6-0510-48cc-936a-d12b32a7caad",
-        "title": "Application Software",
-    },
-    "asset_management": {
-        "desc": "Asset Management Stocks",
-        "id": "c8b32fcc-27e5-48c0-b45a-901fa1f981c7",
-        "title": "Asset Management",
-    },
-    "auto_dealerships": {
-        "desc": "Auto Dealerships Stocks",
-        "id": "a33dfb81-0ee0-476e-a4b5-16c3f5ef2fe9",
-        "title": "Auto Dealerships",
-    },
-    "auto_manufacturers_major": {
-        "desc": "Auto Manufacturers - Major Stocks",
-        "id": "18c9d96e-5413-459a-afbc-87e7cac6765e",
-        "title": "Auto Manufacturers - Major",
-    },
-    "auto_parts": {
-        "desc": "Auto Parts Stocks",
-        "id": "a56d1cdc-a25f-4568-b209-c6330340a4b3",
-        "title": "Auto Parts",
-    },
-    "auto_parts_stores": {
-        "desc": "Auto Parts Stores Stocks",
-        "id": "d204ac1e-7e43-408a-883f-34ed3cf79444",
-        "title": "Auto Parts Stores",
-    },
-    "auto_parts_wholesale": {
-        "desc": "Auto Parts Wholesale Stocks",
-        "id": "fb7cb783-c282-493e-9047-2f8530edb7f1",
-        "title": "Auto Parts Wholesale",
-    },
-    "basic_materials": {
-        "desc": "Basic Materials Stocks",
-        "id": "3a697e76-9648-4570-813e-b4a459c2e33c",
-        "title": "Basic Materials",
-    },
-    "basic_materials_wholesale": {
-        "desc": "Basic Materials Wholesale Stocks",
-        "id": "151e09fd-6d7f-41d0-b196-4d08f61c6ec4",
-        "title": "Basic Materials Wholesale",
-    },
-    "beverages_brewers": {
-        "desc": "Beverages - Brewers Stocks",
-        "id": "043856ac-2e8e-4267-8315-7fbc4d1f166b",
-        "title": "Beverages - Brewers",
-    },
-    "beverages_soft_drinks": {
-        "desc": "Beverages - Soft Drinks Stocks",
-        "id": "e426103b-1e77-40e9-912e-cd34c79d9b67",
-        "title": "Beverages - Soft Drinks",
-    },
-    "beverages_wineries_distillers": {
-        "desc": "Beverages - Wineries & Distillers Stocks",
-        "id": "8c0afa98-c552-4169-9a0a-0472d32f68cc",
-        "title": "Beverages - Wineries & Distillers",
-    },
-    "biotechnology": {
-        "desc": "Biotechnology Stocks",
-        "id": "71a482da-da21-4935-9c62-1bec97e548ae",
-        "title": "Biotechnology",
-    },
-    "broadcasting_radio": {
-        "desc": "Broadcasting - Radio Stocks",
-        "id": "8f516b9c-261f-444c-b2f8-893fceea46b9",
-        "title": "Broadcasting - Radio",
-    },
-    "broadcasting_tv": {
-        "desc": "Broadcasting - TV Stocks",
-        "id": "4de7dc2e-4afb-44c6-8f8a-a72040347bbe",
-        "title": "Broadcasting - TV",
-    },
-    "building_materials_wholesale": {
-        "desc": "Building Materials Wholesale Stocks",
-        "id": "28f66d1e-7c42-488b-b042-a752587878eb",
-        "title": "Building Materials Wholesale",
-    },
-    "business_equipment": {
-        "desc": "Business Equipment Stocks",
-        "id": "7cba798a-cc73-4df8-b9af-d8d6f1b8d95d",
-        "title": "Business Equipment",
-    },
-    "business_services": {
-        "desc": "Business Services Stocks",
-        "id": "744edb19-119e-40e4-82e4-d08f09edf47c",
-        "title": "Business Services",
-    },
-    "business_software_services": {
-        "desc": "Business Software & Services Stocks",
-        "id": "2c2d6477-dbc6-4253-aca9-e1683baf0a9e",
-        "title": "Business Software & Services",
-    },
-    "catalog_mail_order_houses": {
-        "desc": "Catalog & Mail Order Houses Stocks",
-        "id": "119f488f-e4c6-4c3b-a893-e7d3d0b4a385",
-        "title": "Catalog & Mail Order Houses",
-    },
-    "catv_systems": {
-        "desc": "CATV Systems Stocks",
-        "id": "a688d87a-fc1a-46c5-9fd6-8c0bd30342b2",
-        "title": "CATV Systems",
-    },
-    "cement": {
-        "desc": "Cement Stocks",
-        "id": "b54fa128-31fe-4e28-b805-70e1b70b3717",
-        "title": "Cement",
-    },
-    "chemicals_major_diversified": {
-        "desc": "Chemicals - Major Diversified Stocks",
-        "id": "9c8ad1aa-2133-4986-afe2-4231ebe7719c",
-        "title": "Chemicals - Major Diversified",
-    },
-    "cigarettes": {
-        "desc": "Cigarettes Stocks",
-        "id": "45807e99-39d3-4e4a-931e-c640043af00b",
-        "title": "Cigarettes",
-    },
-    "cleaning_products": {
-        "desc": "Cleaning Products Stocks",
-        "id": "5c26290a-39db-4c1f-886f-4813ae177bab",
-        "title": "Cleaning Products",
-    },
-    "closedend_fund_debt": {
-        "desc": "Closed-End Fund - Debt Stocks",
-        "id": "27534373-2a39-415e-9a67-78d93d35c621",
-        "title": "Closed-End Fund - Debt",
-    },
-    "closedend_fund_equity": {
-        "desc": "Closed-End Fund - Equity Stocks",
-        "id": "5110bb4b-dd13-473f-afd9-0e799c46cb48",
-        "title": "Closed-End Fund - Equity",
-    },
-    "closedend_fund_foreign": {
-        "desc": "Closed-End Fund - Foreign Stocks",
-        "id": "f6a5600c-c870-4550-9a54-868f1cce4b90",
-        "title": "Closed-End Fund - Foreign",
-    },
-    "communication_equipment": {
-        "desc": "Communication Equipment Stocks",
-        "id": "80f748ff-b01a-4bda-a1da-2a9dc9398964",
-        "title": "Communication Equipment",
-    },
-    "computer_based_systems": {
-        "desc": "Computer Based Systems Stocks",
-        "id": "a3fd7ed8-981a-4c9c-b051-7f22acaec966",
-        "title": "Computer Based Systems",
-    },
-    "computer_peripherals": {
-        "desc": "Computer Peripherals Stocks",
-        "id": "0489f1dd-ef7f-408e-87e5-cff9d2381219",
-        "title": "Computer Peripherals",
-    },
-    "computers_wholesale": {
-        "desc": "Computers Wholesale Stocks",
-        "id": "d802163b-dd42-4617-a656-646996ba96fc",
-        "title": "Computers Wholesale",
-    },
-    "confectioners": {
-        "desc": "Confectioners Stocks",
-        "id": "91abd719-354b-450f-aa0c-ef28cee8c6a7",
-        "title": "Confectioners",
-    },
-    "conglomerates": {
-        "desc": "Conglomerates Stocks",
-        "id": "2ad87ade-6776-4ebf-b82d-99fdd00b4cb9",
-        "title": "Conglomerates",
-    },
-    "conservative_foreign_funds": {
-        "desc": "Foreign funds with Performance Rating of 4 & 5, low risk and top-half returns",
-        "id": "86de34fe-ba77-4c36-be03-19c5d7cf4462",
-        "title": "Conservative Foreign Funds",
-    },
-    "consumer_defensive": {
-        "desc": "Consumer Defensive Stocks",
-        "id": "e0297af8-fc38-4c13-9014-f2565f387214",
-        "title": "Consumer Defensive",
-    },
-    "consumer_goods": {
-        "desc": "Consumer Goods Stocks",
-        "id": "8482bc34-cae2-411b-ac22-5e5ddd3eddbd",
-        "title": "Consumer Goods",
-    },
-    "consumer_services": {
-        "desc": "Consumer Services Stocks",
-        "id": "38fcfdf1-05ac-4b94-8d85-7180c26654c8",
-        "title": "Consumer Services",
-    },
-    "copper": {
-        "desc": "Copper Stocks",
-        "id": "c1e30f24-daa2-4ce7-af9a-67be4812d080",
-        "title": "Copper",
-    },
-    "credit_services": {
-        "desc": "Credit Services Stocks",
-        "id": "0d597b4f-ad90-4748-95cc-85a4fe6a9573",
-        "title": "Credit Services",
-    },
-    "dairy_products": {
-        "desc": "Dairy Products Stocks",
-        "id": "4cc8706a-70fc-4a49-8a44-46ccd0aa887e",
-        "title": "Dairy Products",
-    },
-    "data_storage_devices": {
-        "desc": "Data Storage Devices Stocks",
-        "id": "3b4ad95e-ecf4-44ef-82f1-e0cf59e936f9",
-        "title": "Data Storage Devices",
-    },
-    "day_gainers": {
-        "desc": "Stocks ordered in descending order by price percent change greater than 3% with respect to the previous close",
-        "id": "ec5bebb9-b7b2-4474-9e5c-3e258b61cbe6",
-        "title": "Day Gainers - US",
-    },
-    "day_gainers_americas": {
-        "desc": "stocks ordered in descending order by price percent change greater than 3% with respect to the previous close",
-        "id": "0bfef98d-1a4b-449a-9049-737656446e7c",
-        "title": "Day Gainers Americas",
-    },
-    "day_gainers_asia": {
-        "desc": "stocks ordered in descending order by price percent change greater than 3% with respect to the previous close",
-        "id": "fe852975-302e-413a-bd9c-7a2d602645e9",
-        "title": "Day Gainers Asia",
-    },
-    "day_gainers_au": {
-        "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for Australia",
-        "id": "d0907194-0b84-44d8-8005-054546c8f66b",
-        "title": "Day Gainers - Australia",
-    },
-    "day_gainers_br": {
-        "desc": "Stocks ordered in descending order by price percent change greater than 3% with respect to the previous close",
-        "id": "8fd79848-c838-46bc-986c-7b97414e7d76",
-        "title": "Day Gainers - Brazil",
-    },
-    "day_gainers_ca": {
-        "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for Canada",
-        "id": "4a047ba4-ba4e-4372-8327-202083a89057",
-        "title": "Day Gainers - Canada",
-    },
-    "day_gainers_de": {
-        "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for Germany",
-        "id": "62764a5a-a47b-4a0d-b72a-f454e7b8acfb",
-        "title": "Day Gainers - Germany",
-    },
-    "day_gainers_dji": {
-        "desc": "Day Gainers - Dow Jones Industrials",
-        "id": "9e621bd5-9a7e-4d00-869d-1b1e1b05afd0",
-        "title": "Day Gainers - Dow Jones Industrials",
-    },
-    "day_gainers_es": {
-        "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for Spain",
-        "id": "c50cfd23-75cc-4549-8c57-5029e10f962c",
-        "title": "Day Gainers - Spain",
-    },
-    "day_gainers_europe": {
-        "desc": "stocks ordered in descending order by price percent change greater than 3% with respect to the previous close",
-        "id": "43463575-8b42-4762-9d7e-705588a25dcd",
-        "title": "Day Gainers Europe",
-    },
-    "day_gainers_fr": {
-        "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for France",
-        "id": "9b598d0d-18d5-406e-a807-98d3e63c6afb",
-        "title": "Day Gainers - France",
-    },
-    "day_gainers_gb": {
-        "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for United Kingdom",
-        "id": "97b9075b-c5ab-4c85-bfd3-9694a061e5d2",
-        "title": "Day Gainers - United Kingdom",
-    },
-    "day_gainers_hk": {
-        "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for Hong Kong",
-        "id": "93505957-f2ce-4666-8f7c-91275819b5f6",
-        "title": "Day Gainers - Hong Kong",
-    },
-    "day_gainers_in": {
-        "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for India",
-        "id": "134b914f-e393-4b2e-a824-b4be15517cd8",
-        "title": "Day Gainers - India",
-    },
-    "day_gainers_it": {
-        "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for Italy",
-        "id": "9c86c7ac-c474-40d9-8912-1906cfc6cc1c",
-        "title": "Day Gainers - Italy",
-    },
-    "day_gainers_ndx": {
-        "desc": "Day Gainers - NASDAQ 100",
-        "id": "d1d6e2ab-ca6f-4a7d-a2f2-d872efc816ef",
-        "title": "Day Gainers - NASDAQ 100",
-    },
-    "day_gainers_nz": {
-        "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for New Zealand",
-        "id": "faa6cfcd-cb5d-4dfc-8532-3692ee3cc359",
-        "title": "Day Gainers - New Zealand",
-    },
-    "day_gainers_sg": {
-        "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for Singapore",
-        "id": "4d834f86-c0a9-4211-b7a4-3290011892eb",
-        "title": "Day Gainers - Singapore",
-    },
-    "day_losers": {
-        "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close",
-        "id": "8ecefa87-a8b0-434a-9b39-e061a0baef9b",
-        "title": "Day Losers - US",
-    },
-    "day_losers_americas": {
-        "desc": "stocks ordered in ascending order by price percent change lesser than 2.5% with respect to the previous close",
-        "id": "0e35eb9f-8cf1-4661-a336-e996c1c6f7f8",
-        "title": "Day Losers Americas",
-    },
-    "day_losers_asia": {
-        "desc": "stocks ordered in ascending order by price percent change lesser than 2.5% with respect to the previous close",
-        "id": "37df3812-b9ee-41f0-87e4-b5f893f3198d",
-        "title": "Day Losers Asia",
-    },
-    "day_losers_au": {
-        "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for Australia",
-        "id": "e8e6731f-0eb9-4377-829c-1f61cb670df4",
-        "title": "Day Losers - Australia",
-    },
-    "day_losers_br": {
-        "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for Brazil",
-        "id": "2dd8e3c9-8755-4d02-9bf3-0dd0640d38f2",
-        "title": "Day Losers - Brazil",
-    },
-    "day_losers_ca": {
-        "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for Canada",
-        "id": "44c0eb22-33f1-4bf9-b4d0-e940838b47f5",
-        "title": "Day Losers - Canada",
-    },
-    "day_losers_de": {
-        "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for Germany",
-        "id": "953e5166-b2b3-471c-a765-4c1c3c15b2da",
-        "title": "Day Losers - Germany",
-    },
-    "day_losers_dji": {
-        "desc": "Day Losers - Dow Jones Industrials",
-        "id": "c95c79eb-8b89-461b-b4cf-680cf77f057e",
-        "title": "Day Losers - Dow Jones Industrials",
-    },
-    "day_losers_es": {
-        "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for Spain",
-        "id": "80678708-0b02-409b-a378-15965a930d60",
-        "title": "Day Losers - Spain",
-    },
-    "day_losers_europe": {
-        "desc": "stocks ordered in ascending order by price percent change lesser than 2.5% with respect to the previous close",
-        "id": "3dfde79b-6160-4da3-a042-d1a86fd5eff9",
-        "title": "Day Losers Europe",
-    },
-    "day_losers_fr": {
-        "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for France",
-        "id": "bb9aaa7a-935e-49de-999e-e5b86c9aeefa",
-        "title": "Day Losers - France",
-    },
-    "day_losers_gb": {
-        "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for United Kingdom",
-        "id": "01a3b7ec-c577-401f-8b19-57d6bbf5ce8e",
-        "title": "Day Losers - United Kingdom",
-    },
-    "day_losers_hk": {
-        "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for Hong Kong",
-        "id": "5d940688-4853-49bd-a3b3-849ca743ad8c",
-        "title": "Day Losers - Hong Kong",
-    },
-    "day_losers_in": {
-        "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for India",
-        "id": "d17726f5-6c05-4c80-9cc9-3578febcdb3c",
-        "title": "Day Losers - India",
-    },
-    "day_losers_it": {
-        "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for Italy",
-        "id": "46677e46-895d-4c5c-a938-577d80df2180",
-        "title": "Day Losers - Italy",
-    },
-    "day_losers_ndx": {
-        "desc": "Day Losers - NASDAQ 100",
-        "id": "b72e29e8-dfc2-428e-ab3f-e69df2008457",
-        "title": "Day Losers - NASDAQ 100",
-    },
-    "day_losers_nz": {
-        "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for New Zealand",
-        "id": "ce6dcbd1-c853-402a-90b4-776865c76f5d",
-        "title": "Day Losers - New Zealand",
-    },
-    "day_losers_sg": {
-        "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for Singapore",
-        "id": "87813bf9-1d84-4d03-9552-d5ee38666ca4",
-        "title": "Day Losers - Singapore",
-    },
-    "department_stores": {
-        "desc": "Department Stores Stocks",
-        "id": "24ffe437-b88f-4eed-892e-28fde7411704",
-        "title": "Department Stores",
-    },
-    "diagnostic_substances": {
-        "desc": "Diagnostic Substances Stocks",
-        "id": "0d21e4d3-1f56-47f3-aa5b-84355c008c35",
-        "title": "Diagnostic Substances",
-    },
-    "discount_variety_stores": {
-        "desc": "Discount, Variety Stores Stocks",
-        "id": "eb64feb5-cad7-4fc3-a113-6ebff0afc18c",
-        "title": "Discount, Variety Stores",
-    },
-    "diversified_communication_services": {
-        "desc": "Diversified Communication Services Stocks",
-        "id": "b440c77b-d1a5-44d9-a907-f46e26de393b",
-        "title": "Diversified Communication Services",
-    },
-    "diversified_computer_systems": {
-        "desc": "Diversified Computer Systems Stocks",
-        "id": "dc87c541-0d89-47d2-bfc0-0e6ad698ac01",
-        "title": "Diversified Computer Systems",
-    },
-    "diversified_electronics": {
-        "desc": "Diversified Electronics Stocks",
-        "id": "56ba316c-b776-4262-8b3c-2eb8bc94ba13",
-        "title": "Diversified Electronics",
-    },
-    "diversified_investments": {
-        "desc": "Diversified Investments Stocks",
-        "id": "00dcd5c5-3958-4f35-8ee0-a9e006783b4c",
-        "title": "Diversified Investments",
-    },
-    "diversified_machinery": {
-        "desc": "Diversified Machinery Stocks",
-        "id": "7045196f-41b5-4de6-b665-132e8438f025",
-        "title": "Diversified Machinery",
-    },
-    "diversified_utilities": {
-        "desc": "Diversified Utilities Stocks",
-        "id": "07d94519-1c27-443d-8e75-7328d49e86f6",
-        "title": "Diversified Utilities",
-    },
-    "drug_delivery": {
-        "desc": "Drug Delivery Stocks",
-        "id": "5e3f50e6-a2b5-47f6-b508-3574e0e0210d",
-        "title": "Drug Delivery",
-    },
-    "drug_manufacturers_major": {
-        "desc": "Drug Manufacturers - Major Stocks",
-        "id": "e2c86234-82cd-4ad3-9271-19f8e9fb35aa",
-        "title": "Drug Manufacturers - Major",
-    },
-    "drug_manufacturers_other": {
-        "desc": "Drug Manufacturers - Other Stocks",
-        "id": "a413147e-a405-4976-8004-f781e30fb241",
-        "title": "Drug Manufacturers - Other",
-    },
-    "drug_related_products": {
-        "desc": "Drug Related Products Stocks",
-        "id": "0ff7e555-433a-489d-93a9-a93cbdc56089",
-        "title": "Drug Related Products",
-    },
-    "drug_stores": {
-        "desc": "Drug Stores Stocks",
-        "id": "84871e44-d1de-4972-afa9-1f95abc59704",
-        "title": "Drug Stores",
-    },
-    "drugs_generic": {
-        "desc": "Drugs - Generic Stocks",
-        "id": "1383c698-cfc4-4fce-8cae-6ba59a0f7daf",
-        "title": "Drugs - Generic",
-    },
-    "drugs_wholesale": {
-        "desc": "Drugs Wholesale Stocks",
-        "id": "d9f21701-62f1-449f-bc05-7f9003d5623b",
-        "title": "Drugs Wholesale",
-    },
-    "education_training_services": {
-        "desc": "Education & Training Services Stocks",
-        "id": "70d6d9f2-e322-47ab-8af7-8c2409d0d9c1",
-        "title": "Education & Training Services",
-    },
-    "electric_utilities": {
-        "desc": "Electric Utilities Stocks",
-        "id": "7a550537-69a2-4a77-959a-dadc215a5ddf",
-        "title": "Electric Utilities",
-    },
-    "electronic_equipment": {
-        "desc": "Electronic Equipment Stocks",
-        "id": "e9f52eae-f0aa-4cb0-810b-5ae77cfa9724",
-        "title": "Electronic Equipment",
-    },
-    "electronics_stores": {
-        "desc": "Electronics Stores Stocks",
-        "id": "1249fb8d-cf84-4e1a-b861-534988ef060a",
-        "title": "Electronics Stores",
-    },
-    "electronics_wholesale": {
-        "desc": "Electronics Wholesale Stocks",
-        "id": "bd8db9b6-3df9-4d6b-852e-1fa52904d7c0",
-        "title": "Electronics Wholesale",
-    },
-    "entertainment_diversified": {
-        "desc": "Entertainment - Diversified Stocks",
-        "id": "226de064-c772-4d48-bdaf-6ec67708630c",
-        "title": "Entertainment - Diversified",
-    },
-    "fair_value_screener": {
-        "desc": "Undervalued stocks with a strong & consistent history of earnings and revenue growth",
-        "id": "e2276d18-9203-4b75-8efd-0f3b5f5cde94",
-        "title": "Fair Value Screener",
-    },
-    "farm_construction_machinery": {
-        "desc": "Farm & Construction Machinery Stocks",
-        "id": "5e4c5e8e-c19a-41ee-bec1-ee36376fd22a",
-        "title": "Farm & Construction Machinery",
-    },
-    "farm_products": {
-        "desc": "Farm Products Stocks",
-        "id": "389cb282-102f-4933-a5fb-16a55f02b7ee",
-        "title": "Farm Products",
-    },
-    "financial": {
-        "desc": "Financial Stocks",
-        "id": "69db7777-6328-4583-abfc-6c69beaac7e4",
-        "title": "Financial",
-    },
-    "food_major_diversified": {
-        "desc": "Food - Major Diversified Stocks",
-        "id": "f70a22e4-bc9d-437b-a536-86c77d3b9dd3",
-        "title": "Food - Major Diversified",
-    },
-    "food_wholesale": {
-        "desc": "Food Wholesale Stocks",
-        "id": "7c0ddc36-9c35-438c-aff6-d7f0db59886b",
-        "title": "Food Wholesale",
-    },
-    "foreign_money_center_banks": {
-        "desc": "Foreign Money Center Banks Stocks",
-        "id": "e9da5c1c-630f-431a-ae46-5518a21c126b",
-        "title": "Foreign Money Center Banks",
-    },
-    "foreign_regional_banks": {
-        "desc": "Foreign Regional Banks Stocks",
-        "id": "0bbb6104-c9aa-431e-a01e-6e5fa08b092b",
-        "title": "Foreign Regional Banks",
-    },
-    "foreign_utilities": {
-        "desc": "Foreign Utilities Stocks",
-        "id": "d8e3034c-0ca3-4d18-860d-b386ae1649dc",
-        "title": "Foreign Utilities",
-    },
-    "gaming_activities": {
-        "desc": "Gaming Activities Stocks",
-        "id": "77b7b262-53a1-4ad0-a2a9-af1ce9830628",
-        "title": "Gaming Activities",
-    },
-    "gas_utilities": {
-        "desc": "Gas Utilities Stocks",
-        "id": "268fe346-d356-477c-98fa-a94998bf5f80",
-        "title": "Gas Utilities",
-    },
-    "general_building_materials": {
-        "desc": "General Building Materials Stocks",
-        "id": "274cb728-f9c9-4a19-94b9-b372288e1cd1",
-        "title": "General Building Materials",
-    },
-    "general_contractors": {
-        "desc": "General Contractors Stocks",
-        "id": "60936002-4c04-49c1-b1cd-102ce5278296",
-        "title": "General Contractors",
-    },
-    "general_entertainment": {
-        "desc": "General Entertainment Stocks",
-        "id": "acbbf9d0-8b69-4e0b-a187-ea5c304b9cfb",
-        "title": "General Entertainment",
-    },
-    "gold": {
-        "desc": "Gold Stocks",
-        "id": "2361c12d-b555-46a3-8a02-f4af101ce899",
-        "title": "Gold",
-    },
-    "grocery_stores": {
-        "desc": "Grocery Stores Stocks",
-        "id": "1e5a01cd-20a5-4fee-91a2-49db0b2e7068",
-        "title": "Grocery Stores",
-    },
-    "growth_technology_stocks": {
-        "desc": "Technology stocks with revenue and earnings growth in excess of 25%.",
-        "id": "e0c43708-7fa1-4f02-9425-697c0443d32f",
-        "title": "Growth Technology Stocks",
-    },
-    "health_care_plans": {
-        "desc": "Health Care Plans Stocks",
-        "id": "7b7cae71-7acc-4845-89f1-50d4e968f9b2",
-        "title": "Health Care Plans",
-    },
-    "healthcare": {
-        "desc": "Healthcare Stocks",
-        "id": "a61c851f-5d25-4237-878f-db9c46040b1a",
-        "title": "Healthcare",
-    },
-    "healthcare_information_services": {
-        "desc": "Healthcare Information Services Stocks",
-        "id": "fd595c95-cf2e-4bdd-8916-f8725015e19a",
-        "title": "Healthcare Information Services",
-    },
-    "heavy_construction": {
-        "desc": "Heavy Construction Stocks",
-        "id": "9e2a27dd-c3c4-4859-8605-cbe9fe1ebac4",
-        "title": "Heavy Construction",
-    },
-    "high_yield_bond": {
-        "desc": "High Yield Bond with Performance Rating of 4 & 5, low risk and top-half returns",
-        "id": "d675527c-bc6a-486c-872d-bca43fbb4322",
-        "title": "High Yield Bond",
-    },
-    "home_furnishing_stores": {
-        "desc": "Home Furnishing Stores Stocks",
-        "id": "1878c038-4c2c-4ded-afd2-9cea57212d7f",
-        "title": "Home Furnishing Stores",
-    },
-    "home_furnishings_fixtures": {
-        "desc": "Home Furnishings & Fixtures Stocks",
-        "id": "bf4e278f-23d5-4b48-895f-94de35890d99",
-        "title": "Home Furnishings & Fixtures",
-    },
-    "home_health_care": {
-        "desc": "Home Health Care Stocks",
-        "id": "4cc4a8d5-6cad-443b-8a58-5defb06a4e4d",
-        "title": "Home Health Care",
-    },
-    "home_improvement_stores": {
-        "desc": "Home Improvement Stores Stocks",
-        "id": "088b187c-667a-4e12-97b3-17c9c7c8f98a",
-        "title": "Home Improvement Stores",
-    },
-    "hospitals": {
-        "desc": "Hospitals Stocks",
-        "id": "651ab7b2-1214-41b8-9f7a-83dc7841fb10",
-        "title": "Hospitals",
-    },
-    "housewares_accessories": {
-        "desc": "Housewares & Accessories Stocks",
-        "id": "142a2ee4-cfc1-45d7-83c0-30e737c8931a",
-        "title": "Housewares & Accessories",
-    },
-    "independent_oil_gas": {
-        "desc": "Independent Oil & Gas Stocks",
-        "id": "cac7e5ae-03af-435e-8ca4-e33eeb82a61a",
-        "title": "Independent Oil & Gas",
-    },
-    "industrial_electrical_equipment": {
-        "desc": "Industrial Electrical Equipment Stocks",
-        "id": "bd3aa4dc-6f42-44f7-82fa-b934b7be253f",
-        "title": "Industrial Electrical Equipment",
-    },
-    "industrial_equipment_components": {
-        "desc": "Industrial Equipment & Components Stocks",
-        "id": "f2a8afa0-0aae-4fac-9463-7af4e30f85af",
-        "title": "Industrial Equipment & Components",
-    },
-    "industrial_equipment_wholesale": {
-        "desc": "Industrial Equipment Wholesale Stocks",
-        "id": "c311f83c-1e52-43e2-a20d-b34196bcb9e7",
-        "title": "Industrial Equipment Wholesale",
-    },
-    "industrial_goods": {
-        "desc": "Industrial Goods Stocks",
-        "id": "3451cc5c-1271-4bbb-be1b-3e3d0c10d066",
-        "title": "Industrial Goods",
-    },
-    "industrial_metals_minerals": {
-        "desc": "Industrial Metals & Minerals Stocks",
-        "id": "0c13eed7-59eb-40aa-bf7d-e8b6da6c30b4",
-        "title": "Industrial Metals & Minerals",
-    },
-    "information_delivery_services": {
-        "desc": "Information & Delivery Services Stocks",
-        "id": "8e9c42cd-636e-458d-89f9-16b61cf5b099",
-        "title": "Information & Delivery Services",
-    },
-    "information_technology_services": {
-        "desc": "Information Technology Services Stocks",
-        "id": "1f8fc3f6-7cdc-4a87-ab63-b637a0cc9598",
-        "title": "Information Technology Services",
-    },
-    "insurance_brokers": {
-        "desc": "Insurance Brokers Stocks",
-        "id": "3d08fef1-d735-476c-9f41-c32af4e5d15d",
-        "title": "Insurance Brokers",
-    },
-    "internet_information_providers": {
-        "desc": "Internet Information Providers Stocks",
-        "id": "a671a9f8-b6b8-40ac-9a9b-46ae5a2dda6a",
-        "title": "Internet Information Providers",
-    },
-    "internet_service_providers": {
-        "desc": "Internet Service Providers Stocks",
-        "id": "b2a97d8e-a938-40c5-af08-cdf747f50e43",
-        "title": "Internet Service Providers",
-    },
-    "internet_software_services": {
-        "desc": "Internet Software & Services Stocks",
-        "id": "a74c2a53-c957-4138-858e-7e4a71539366",
-        "title": "Internet Software & Services",
-    },
-    "investment_brokerage_national": {
-        "desc": "Investment Brokerage - National Stocks",
-        "id": "804969f0-ae71-429f-870c-dd3adef438b4",
-        "title": "Investment Brokerage - National",
-    },
-    "investment_brokerage_regional": {
-        "desc": "Investment Brokerage - Regional Stocks",
-        "id": "263ea65b-20df-457b-b930-c238df5518f0",
-        "title": "Investment Brokerage - Regional",
-    },
-    "jewelry_stores": {
-        "desc": "Jewelry Stores Stocks",
-        "id": "1df9286d-94b0-4d92-ac9d-a410a3c3df37",
-        "title": "Jewelry Stores",
-    },
-    "life_insurance": {
-        "desc": "Life Insurance Stocks",
-        "id": "3505160e-06db-470a-ab0c-a990d7c1a7a3",
-        "title": "Life Insurance",
-    },
-    "lodging": {
-        "desc": "Lodging Stocks",
-        "id": "e0ff1766-911e-41fe-a356-4772ef8703ad",
-        "title": "Lodging",
-    },
-    "long_distance_carriers": {
-        "desc": "Long Distance Carriers Stocks",
-        "id": "4064e669-0900-4525-a0ed-95039ddb0981",
-        "title": "Long Distance Carriers",
-    },
-    "longterm_care_facilities": {
-        "desc": "Long-Term Care Facilities Stocks",
-        "id": "82ed357c-b4ae-4912-b102-ad271dd50265",
-        "title": "Long-Term Care Facilities",
-    },
-    "lumber_wood_production": {
-        "desc": "Lumber, Wood Production Stocks",
-        "id": "abb9694b-cb82-4d73-9458-fcb21be6a816",
-        "title": "Lumber, Wood Production",
-    },
-    "machine_tools_accessories": {
-        "desc": "Machine Tools & Accessories Stocks",
-        "id": "af60e5a3-129a-4dd9-9caa-398bb38d6219",
-        "title": "Machine Tools & Accessories",
-    },
-    "major_airlines": {
-        "desc": "Major Airlines Stocks",
-        "id": "f37f3659-ec67-417c-a748-e64635c8f5a9",
-        "title": "Major Airlines",
-    },
-    "major_integrated_oil_gas": {
-        "desc": "Major Integrated Oil & Gas Stocks",
-        "id": "0a277914-9c11-438b-867e-587f670b3f27",
-        "title": "Major Integrated Oil & Gas",
-    },
-    "management_services": {
-        "desc": "Management Services Stocks",
-        "id": "b8ac48d0-53cb-45b0-8ccd-b85340de0ae2",
-        "title": "Management Services",
-    },
-    "marketing_services": {
-        "desc": "Marketing Services Stocks",
-        "id": "c96ef7b9-c96d-4846-bce4-41d33234e265",
-        "title": "Marketing Services",
-    },
-    "meat_products": {
-        "desc": "Meat Products Stocks",
-        "id": "61c71d7f-5c7f-472a-afda-6dca4933bd74",
-        "title": "Meat Products",
-    },
-    "medical_appliances_equipment": {
-        "desc": "Medical Appliances & Equipment Stocks",
-        "id": "49324014-202d-4719-a1b7-a28b622b474b",
-        "title": "Medical Appliances & Equipment",
-    },
-    "medical_equipment_wholesale": {
-        "desc": "Medical Equipment Wholesale Stocks",
-        "id": "e73da5ae-176a-4b0f-a7e0-1c00ab46f95c",
-        "title": "Medical Equipment Wholesale",
-    },
-    "medical_instruments_supplies": {
-        "desc": "Medical Instruments & Supplies Stocks",
-        "id": "a4d4cafc-9ecd-41d5-8ef6-a8a40671aa35",
-        "title": "Medical Instruments & Supplies",
-    },
-    "medical_laboratories_research": {
-        "desc": "Medical Laboratories & Research Stocks",
-        "id": "79cf089e-8853-4d61-8216-8c69c3a2ecad",
-        "title": "Medical Laboratories & Research",
-    },
-    "mega_cap_hc": {
-        "desc": "Stocks with Mega Cap in healthcare industry",
-        "id": "86889bb3-e9d9-464d-956a-4abe5a9728db",
-        "title": "Mega Cap Healthcare",
-    },
-    "metal_fabrication": {
-        "desc": "Metal Fabrication Stocks",
-        "id": "78a2d4ca-f254-4cca-8d13-38f838bb504d",
-        "title": "Metal Fabrication",
-    },
-    "money_center_banks": {
-        "desc": "Money Center Banks Stocks",
-        "id": "f9ad3ccf-37ab-4041-9c67-eabab432c28d",
-        "title": "Money Center Banks",
-    },
-    "mortgage_investment": {
-        "desc": "Mortgage Investment Stocks",
-        "id": "5d96c8d0-7a02-4e20-a420-cefb9e859048",
-        "title": "Mortgage Investment",
-    },
-    "most_actives": {
-        "desc": "Stocks ordered in descending order by intraday trade volume",
-        "id": "437465ef-980e-4d8c-a860-de7cbfbab373",
-        "title": "Most Actives - US",
-    },
-    "most_actives_americas": {
-        "desc": "Stocks ordered in descending order by intraday trade volume",
-        "id": "a143f34f-7d90-473b-855b-67787326ce2c",
-        "title": "Most Actives Americas",
-    },
-    "most_actives_asia": {
-        "desc": "Stocks ordered in descending order by intraday trade volume",
-        "id": "2e23187d-c4ff-48a5-b498-161a80b0145b",
-        "title": "Most Actives Asia",
-    },
-    "most_actives_au": {
-        "desc": "Stocks ordered in descending order by intraday trade volume for Australia",
-        "id": "d0dad29a-9a50-445b-8ca4-1367e51826eb",
-        "title": "Most Actives - Australia",
-    },
-    "most_actives_br": {
-        "desc": "Stocks ordered in descending order by intraday trade volume for Brazil",
-        "id": "ec23a32d-e108-465f-9d4b-e5db1d934f2e",
-        "title": "Most Actives - Brazil",
-    },
-    "most_actives_ca": {
-        "desc": "Stocks ordered in descending order by intraday trade volume for Canada",
-        "id": "5026cc58-c878-4f43-af38-efbffadce77f",
-        "title": "Most Actives - Canada",
-    },
-    "most_actives_de": {
-        "desc": "Stocks ordered in descending order by intraday trade volume for Germany",
-        "id": "5b4148d2-5a6d-4466-b663-b5895f5bc583",
-        "title": "Most Actives - Germany",
-    },
-    "most_actives_dji": {
-        "desc": "No description",
-        "id": "a423c5d4-9eff-4fb5-9995-93d06480ea91",
-        "title": "Most Actives - NASDAQ 100",
-    },
-    "most_actives_es": {
-        "desc": "Stocks ordered in descending order by intraday trade volume for Spain",
-        "id": "8d1545dc-2fd9-4cac-854e-88f74c54b5dc",
-        "title": "Most Actives - Spain",
-    },
-    "most_actives_europe": {
-        "desc": "Stocks ordered in descending order by intraday trade volume",
-        "id": "c46c7edd-c97f-4929-9ade-77ec21b86c18",
-        "title": "Most Actives Europe",
-    },
-    "most_actives_fr": {
-        "desc": "Stocks ordered in descending order by intraday trade volume for France",
-        "id": "05f97149-f902-4cd3-8f72-f7768ac673e0",
-        "title": "Most Actives - France",
-    },
-    "most_actives_gb": {
-        "desc": "Stocks ordered in descending order by intraday trade volume for United Kingdom",
-        "id": "433c5af8-f58f-4d92-8338-7d928f558a0d",
-        "title": "Most Actives - United Kingdom",
-    },
-    "most_actives_hk": {
-        "desc": "Stocks ordered in descending order by intraday trade volume for Hong Kong",
-        "id": "9dbdb8ef-d0c2-446f-baab-be6997a20be8",
-        "title": "Most Actives - Hong Kong",
-    },
-    "most_actives_in": {
-        "desc": "Stocks ordered in descending order by intraday trade volume for India",
-        "id": "09a035cc-f535-4249-bfae-ed95e7a9e12e",
-        "title": "Most Actives - India",
-    },
-    "most_actives_it": {
-        "desc": "Stocks ordered in descending order by intraday trade volume for Italy",
-        "id": "2ec96414-6fb7-4da4-8600-cf6f82d0e6d8",
-        "title": "Most Actives - Italy",
-    },
-    "most_actives_ndx": {
-        "desc": "No description",
-        "id": "393c6a0f-d975-45a7-91b5-478fd3847b31",
-        "title": "Most Actives - NASDAQ 100",
-    },
-    "most_actives_nz": {
-        "desc": "Stocks ordered in descending order by intraday trade volume for New Zealand",
-        "id": "b6b57880-3ce5-4f10-943b-a5b6dbf77f4d",
-        "title": "Most Actives - New Zealand",
-    },
-    "most_actives_sg": {
-        "desc": "Stocks ordered in descending order by intraday trade volume for Singapore",
-        "id": "96384b8f-b161-4eef-abf8-d1ce290da125",
-        "title": "Most Actives - Singapore",
-    },
-    "most_watched_tickers": {
-        "desc": "Top 30 tickers with highest portfolioheldcount",
-        "id": "04c9d12e-f0a3-4ab8-bab8-904a2d1c3ab2",
-        "title": "Most added to watchlist",
-    },
-    "movie_production_theaters": {
-        "desc": "Movie Production, Theaters Stocks",
-        "id": "6a3ac566-2922-470c-b06e-efd97588c0de",
-        "title": "Movie Production, Theaters",
-    },
-    "ms_basic_materials": {
-        "desc": "Basic Materials ordered by intra day market cap for US region",
-        "id": "a4f8a58b-e458-44fe-b304-04af382a364e",
-        "title": "Basic Materials Sector",
-    },
-    "ms_communication_services": {
-        "desc": "Communication Services ordered by intra day market cap for US region",
-        "id": "b8a44a72-2d49-4a2f-9261-f0fff3c2e4e2",
-        "title": "Communication Services Sector",
-    },
-    "ms_consumer_cyclical": {
-        "desc": "Consumer Cyclical ordered by intra day market cap for US region",
-        "id": "4969e5a1-b0e0-416e-9ae3-191414339e3a",
-        "title": "Consumer Cyclical Sector",
-    },
-    "ms_consumer_defensive": {
-        "desc": "Consumer Defensive ordered by intra day market cap for US region",
-        "id": "6a15b340-2e3c-44a6-b339-b7ae5c097be5",
-        "title": "Consumer Defensive Sector",
-    },
-    "ms_energy": {
-        "desc": "Energy Services ordered by intra day market cap for US region",
-        "id": "2efb4ff8-64f4-4941-abb5-a399a6d0f66a",
-        "title": "Energy Services Sector",
-    },
-    "ms_financial_services": {
-        "desc": "Financial Services ordered by intra day market cap for US region",
-        "id": "667f5248-3710-40d9-8d95-6582fdfa254c",
-        "title": "Financial Services Sector",
-    },
-    "ms_healthcare": {
-        "desc": "Healthcare ordered by intra day market cap for US region",
-        "id": "e568d534-af60-4d20-a192-93bd4508f1bf",
-        "title": "Healthcare Sector",
-    },
-    "ms_industrials": {
-        "desc": "Industrials Services ordered by intra day market cap for US region",
-        "id": "caf102b6-2c28-4abc-9d81-b13d710af432",
-        "title": "Industrials Services Sector",
-    },
-    "ms_real_estate": {
-        "desc": "Real Estate ordered by intra day market cap for US region",
-        "id": "69d56754-89fd-4bc4-9f57-66ed42291311",
-        "title": "Real Estate Sector",
-    },
-    "ms_technology": {
-        "desc": "Technology Services ordered by intra day market cap for US region",
-        "id": "c7b3f121-188a-4846-83e4-f049fab045cd",
-        "title": "Technology Services Sector",
-    },
-    "ms_utilities": {
-        "desc": "Utilities ordered by intra day market cap for US region",
-        "id": "590cedc7-6ddc-40dc-9839-68b0c1572274",
-        "title": "Utilities Sector",
-    },
-    "multimedia_graphics_software": {
-        "desc": "Multimedia & Graphics Software Stocks",
-        "id": "2b41b48d-efd5-442f-b099-0833b5d1859a",
-        "title": "Multimedia & Graphics Software",
-    },
-    "networking_communication_devices": {
-        "desc": "Networking & Communication Devices Stocks",
-        "id": "c6b5fb38-2fc3-4376-a664-e5ec18498fcd",
-        "title": "Networking & Communication Devices",
-    },
-    "nonmetallic_mineral_mining": {
-        "desc": "Nonmetallic Mineral Mining Stocks",
-        "id": "680d4cfb-49d5-4647-9969-091f0f607b3e",
-        "title": "Nonmetallic Mineral Mining",
-    },
-    "office_supplies": {
-        "desc": "Office Supplies Stocks",
-        "id": "bd1d7317-6569-4b97-a261-1079c0d4742e",
-        "title": "Office Supplies",
-    },
-    "oil_gas_drilling_exploration": {
-        "desc": "Oil & Gas Drilling & Exploration Stocks",
-        "id": "c0eda629-1a01-467c-a7a8-87c3bbadd8f2",
-        "title": "Oil & Gas Drilling & Exploration",
-    },
-    "oil_gas_equipment_services": {
-        "desc": "Oil & Gas Equipment & Services Stocks",
-        "id": "497e4a9f-6092-4b97-9169-5030371cf138",
-        "title": "Oil & Gas Equipment & Services",
-    },
-    "oil_gas_pipelines": {
-        "desc": "Oil & Gas Pipelines Stocks",
-        "id": "cc2e1037-0c46-4457-8ec6-fe6c253d09b1",
-        "title": "Oil & Gas Pipelines",
-    },
-    "oil_gas_refining_marketing": {
-        "desc": "Oil & Gas Refining & Marketing Stocks",
-        "id": "8bbbe67c-3680-4833-811f-210b6bd254e3",
-        "title": "Oil & Gas Refining & Marketing",
-    },
-    "packaging_containers": {
-        "desc": "Packaging & Containers Stocks",
-        "id": "af5cd4df-8857-4ff3-9db4-8473b65cdff6",
-        "title": "Packaging & Containers",
-    },
-    "paper_paper_products": {
-        "desc": "Paper & Paper Products Stocks",
-        "id": "6bc68ccf-c574-4e69-a4fc-7a6b1c397de2",
-        "title": "Paper & Paper Products",
-    },
-    "personal_products": {
-        "desc": "Personal Products Stocks",
-        "id": "12365539-b90c-4200-bcdd-c74a49a8d60b",
-        "title": "Personal Products",
-    },
-    "personal_services": {
-        "desc": "Personal Services Stocks",
-        "id": "53860387-1bcc-46ee-af4d-11726648d596",
-        "title": "Personal Services",
-    },
-    "photographic_equipment_supplies": {
-        "desc": "Photographic Equipment & Supplies Stocks",
-        "id": "c5bc5a27-2fd9-4582-ab84-7221f8219fa9",
-        "title": "Photographic Equipment & Supplies",
-    },
-    "pollution_treatment_controls": {
-        "desc": "Pollution & Treatment Controls Stocks",
-        "id": "1278f73b-97e1-4482-bd04-f920c73d5f5f",
-        "title": "Pollution & Treatment Controls",
-    },
-    "portfolio_anchors": {
-        "desc": "Funds with Performance Rating of 4 & 5 and top-half returns that could serve as a rock-solid core of an investor&#39;s portfolio",
-        "id": "7a0584d9-28a1-4a94-ac68-21f0aab91c4a",
-        "title": "Portfolio Anchors",
-    },
-    "printed_circuit_boards": {
-        "desc": "Printed Circuit Boards Stocks",
-        "id": "8e27a780-a6f6-4684-84de-f4741b964c11",
-        "title": "Printed Circuit Boards",
-    },
-    "processed_packaged_goods": {
-        "desc": "Processed & Packaged Goods Stocks",
-        "id": "d3c168fe-81cb-47a0-b51a-03f405006f22",
-        "title": "Processed & Packaged Goods",
-    },
-    "processing_systems_products": {
-        "desc": "Processing Systems & Products Stocks",
-        "id": "a93b4045-47da-4543-8d52-62d698324a43",
-        "title": "Processing Systems & Products",
-    },
-    "property_casualty_insurance": {
-        "desc": "Property & Casualty Insurance Stocks",
-        "id": "4a6b2ed1-fdd1-4d4a-b299-07ba560f8e25",
-        "title": "Property & Casualty Insurance",
-    },
-    "property_management": {
-        "desc": "Property Management Stocks",
-        "id": "e8780dfd-c1e3-4c55-b9d9-2c7506a579da",
-        "title": "Property Management",
-    },
-    "publishing_books": {
-        "desc": "Publishing - Books Stocks",
-        "id": "757c4dea-eb99-4bb2-ba08-f257a351b7bc",
-        "title": "Publishing - Books",
-    },
-    "publishing_newspapers": {
-        "desc": "Publishing - Newspapers Stocks",
-        "id": "5c8fef92-9388-43b7-9638-d2a7b1ecebf5",
-        "title": "Publishing - Newspapers",
-    },
-    "publishing_periodicals": {
-        "desc": "Publishing - Periodicals Stocks",
-        "id": "6b166e73-b531-443c-8401-626a1a224af2",
-        "title": "Publishing - Periodicals",
-    },
-    "railroads": {
-        "desc": "Railroads Stocks",
-        "id": "f70bbf07-292b-4918-9cc0-4d553de4bd8c",
-        "title": "Railroads",
-    },
-    "real_estate_development": {
-        "desc": "Real Estate Development Stocks",
-        "id": "aa93b691-8dd7-4533-9edd-19af1e943893",
-        "title": "Real Estate Development",
-    },
-    "recreational_goods_other": {
-        "desc": "Recreational Goods, Other Stocks",
-        "id": "666c8f36-235f-4ce3-9a5d-0fc64eae056a",
-        "title": "Recreational Goods, Other",
-    },
-    "recreational_vehicles": {
-        "desc": "Recreational Vehicles Stocks",
-        "id": "44e1a55d-5988-4f5b-84f6-0d6173b54f32",
-        "title": "Recreational Vehicles",
-    },
-    "regional_airlines": {
-        "desc": "Regional Airlines Stocks",
-        "id": "3852fca0-8999-45da-921c-0dd693d719d0",
-        "title": "Regional Airlines",
-    },
-    "regional_midatlantic_banks": {
-        "desc": "Regional - Mid-Atlantic Banks Stocks",
-        "id": "793ad3df-476d-454d-8870-7b63d12f8c68",
-        "title": "Regional - Mid-Atlantic Banks",
-    },
-    "regional_midwest_banks": {
-        "desc": "Regional - Midwest Banks Stocks",
-        "id": "a2f4d18d-59e4-44bc-b1a9-810b5d990c2d",
-        "title": "Regional - Midwest Banks",
-    },
-    "regional_northeast_banks": {
-        "desc": "Regional - Northeast Banks Stocks",
-        "id": "ead4e367-01b0-431c-a7a5-6e9ff620b1b5",
-        "title": "Regional - Northeast Banks",
-    },
-    "regional_pacific_banks": {
-        "desc": "Regional - Pacific Banks Stocks",
-        "id": "3edd47c6-d35f-4777-9993-8115a07f1196",
-        "title": "Regional - Pacific Banks",
-    },
-    "regional_southeast_banks": {
-        "desc": "Regional - Southeast Banks Stocks",
-        "id": "583f7386-f439-4634-b0e9-c7ddc91fca53",
-        "title": "Regional - Southeast Banks",
-    },
-    "regional_southwest_banks": {
-        "desc": "Regional - Southwest  Banks Stocks",
-        "id": "d6ab7013-47c4-4093-bcc0-7295129c04b1",
-        "title": "Regional - Southwest  Banks",
-    },
-    "reit_diversified": {
-        "desc": "REIT - Diversified Stocks",
-        "id": "1e6617a9-e188-4884-9b45-9ed46c50cbc0",
-        "title": "REIT - Diversified",
-    },
-    "reit_healthcare_facilities": {
-        "desc": "REIT - Healthcare Facilities Stocks",
-        "id": "09d35e37-5c0a-4175-81f9-26141cc761f0",
-        "title": "REIT - Healthcare Facilities",
-    },
-    "reit_hotel_motel": {
-        "desc": "REIT - Hotel/Motel Stocks",
-        "id": "93d32d5b-1933-4625-9337-b94606ea07c7",
-        "title": "REIT - Hotel/Motel",
-    },
-    "reit_industrial": {
-        "desc": "REIT - Industrial Stocks",
-        "id": "f305fc52-f261-4634-b90d-03f5bdcff62c",
-        "title": "REIT - Industrial",
-    },
-    "reit_office": {
-        "desc": "REIT - Office Stocks",
-        "id": "5abcc044-25d8-46e7-86b1-390b0b723de0",
-        "title": "REIT - Office",
-    },
-    "reit_residential": {
-        "desc": "REIT - Residential Stocks",
-        "id": "4386d4b1-7fd8-46f7-bf50-a0a8fad0168f",
-        "title": "REIT - Residential",
-    },
-    "reit_retail": {
-        "desc": "REIT - Retail Stocks",
-        "id": "51c8ff2b-8eb7-44dc-af5d-9362a9e32ae4",
-        "title": "REIT - Retail",
-    },
-    "rental_leasing_services": {
-        "desc": "Rental & Leasing Services Stocks",
-        "id": "1032be0d-8b10-4b56-a5bd-b486f9f2fde3",
-        "title": "Rental & Leasing Services",
-    },
-    "research_services": {
-        "desc": "Research Services Stocks",
-        "id": "855eff0c-5ccf-4932-bd81-faada5c421b0",
-        "title": "Research Services",
-    },
-    "residential_construction": {
-        "desc": "Residential Construction Stocks",
-        "id": "abc687aa-5ab2-4ee1-a5ad-60b3a6cd101c",
-        "title": "Residential Construction",
-    },
-    "resorts_casinos": {
-        "desc": "Resorts & Casinos Stocks",
-        "id": "687857ca-bcee-453c-a7db-ada450592171",
-        "title": "Resorts & Casinos",
-    },
-    "restaurants": {
-        "desc": "Restaurants Stocks",
-        "id": "db208c80-4939-4ab2-b713-86f65fdc0062",
-        "title": "Restaurants",
-    },
-    "rubber_plastics": {
-        "desc": "Rubber & Plastics Stocks",
-        "id": "8424f15b-6a0d-4305-bc8c-84b13aa7d061",
-        "title": "Rubber & Plastics",
-    },
-    "savings_loans": {
-        "desc": "Savings & Loans Stocks",
-        "id": "39a155f1-9d21-46c9-b553-254639d18ffb",
-        "title": "Savings & Loans",
-    },
-    "scientific_technical_instruments": {
-        "desc": "Scientific & Technical Instruments Stocks",
-        "id": "5baed8c8-7232-4616-987c-72b0cb87a0bc",
-        "title": "Scientific & Technical Instruments",
-    },
-    "security_protection_services": {
-        "desc": "Security & Protection Services Stocks",
-        "id": "edc2ddf8-8c95-45e2-bd67-1f554e55421a",
-        "title": "Security & Protection Services",
-    },
-    "security_software_services": {
-        "desc": "Security Software & Services Stocks",
-        "id": "64d8138d-278e-4875-8967-833323ece77b",
-        "title": "Security Software & Services",
-    },
-    "semiconductor_broad_line": {
-        "desc": "Semiconductor - Broad Line Stocks",
-        "id": "6ffcfbf6-53dc-4bab-be70-db7c765b1d32",
-        "title": "Semiconductor - Broad Line",
-    },
-    "semiconductor_equipment_materials": {
-        "desc": "Semiconductor Equipment & Materials Stocks",
-        "id": "bf5bc595-47c8-47ec-a43b-64e2d46bddfe",
-        "title": "Semiconductor Equipment & Materials",
-    },
-    "semiconductor_integrated_circuits": {
-        "desc": "Semiconductor - Integrated Circuits Stocks",
-        "id": "6dce97ee-a6aa-4079-9640-e6aefa3be747",
-        "title": "Semiconductor - Integrated Circuits",
-    },
-    "semiconductor_memory_chips": {
-        "desc": "Semiconductor- Memory Chips Stocks",
-        "id": "9a5fd21d-c5d6-4069-8926-80c301a3b233",
-        "title": "Semiconductor- Memory Chips",
-    },
-    "semiconductor_specialized": {
-        "desc": "Semiconductor - Specialized Stocks",
-        "id": "33b79dbc-6c92-407e-9be7-d3483627042d",
-        "title": "Semiconductor - Specialized",
-    },
-    "services": {
-        "desc": "Services Stocks",
-        "id": "81a63940-a84a-4946-8f24-79c677ec3d79",
-        "title": "Services",
-    },
-    "shipping": {
-        "desc": "Shipping Stocks",
-        "id": "91f32f25-b520-45f7-a6cb-add65a146435",
-        "title": "Shipping",
-    },
-    "silver": {
-        "desc": "Silver Stocks",
-        "id": "225d0c98-78d3-425e-a15e-a6308d461e2b",
-        "title": "Silver",
-    },
-    "small_cap_gainers": {
-        "desc": "Small cap stocks with percentchange greater than 5%",
-        "id": "483129f4-b25a-44c1-afca-8934593f3f6d",
-        "title": "Small caps with momentum",
-    },
-    "small_tools_accessories": {
-        "desc": "Small Tools & Accessories Stocks",
-        "id": "64b34413-0579-4af5-b8ab-4d3117cec9c8",
-        "title": "Small Tools & Accessories",
-    },
-    "solid_large_growth_funds": {
-        "desc": "Large Growth Funds with Performance Rating of 4 & 5 and top-half returns",
-        "id": "5704ade5-098b-4c5e-997f-e50b32be7a55",
-        "title": "Solid Large Growth Funds",
-    },
-    "solid_midcap_growth_funds": {
-        "desc": "Mid-Cap Growth Funds with Performance Rating of 4 & 5 and top-half returns",
-        "id": "d7235ede-59ce-40ad-99f9-5c7e4ec2c5e6",
-        "title": "Solid Mid-Cap Growth Funds",
-    },
-    "specialized_health_services": {
-        "desc": "Specialized Health Services Stocks",
-        "id": "b6c3541d-ad4e-45ec-97bf-e2a9f9a73d1d",
-        "title": "Specialized Health Services",
-    },
-    "specialty_chemicals": {
-        "desc": "Specialty Chemicals Stocks",
-        "id": "0b0c4ef4-b18a-40f1-a938-ef6d140c40da",
-        "title": "Specialty Chemicals",
-    },
-    "specialty_eateries": {
-        "desc": "Specialty Eateries Stocks",
-        "id": "2c0d4e2a-f954-4b84-a1ca-79627b5ec2cf",
-        "title": "Specialty Eateries",
-    },
-    "specialty_retail_other": {
-        "desc": "Specialty Retail, Other Stocks",
-        "id": "0fc02448-1a56-4363-ac79-3521bfe4b95a",
-        "title": "Specialty Retail, Other",
-    },
-    "sporting_activities": {
-        "desc": "Sporting Activities Stocks",
-        "id": "2824bb1b-4e47-4a15-8e06-17ce07f93e4b",
-        "title": "Sporting Activities",
-    },
-    "sporting_goods": {
-        "desc": "Sporting Goods Stocks",
-        "id": "b1576556-303e-47a1-a6a1-54b08c0ed8c3",
-        "title": "Sporting Goods",
-    },
-    "sporting_goods_stores": {
-        "desc": "Sporting Goods Stores Stocks",
-        "id": "26168518-22b6-41dd-a39a-574bcc1b1917",
-        "title": "Sporting Goods Stores",
-    },
-    "staffing_outsourcing_services": {
-        "desc": "Staffing & Outsourcing Services Stocks",
-        "id": "c86a14dd-8ab8-425f-a4fc-421d197067e3",
-        "title": "Staffing & Outsourcing Services",
-    },
-    "steel_iron": {
-        "desc": "Steel & Iron Stocks",
-        "id": "47759edc-a6c8-479a-a9e1-54e90b63404e",
-        "title": "Steel & Iron",
-    },
-    "surety_title_insurance": {
-        "desc": "Surety & Title Insurance Stocks",
-        "id": "8205086d-4d37-47e1-8c8b-80c530feb7fc",
-        "title": "Surety & Title Insurance",
-    },
-    "synthetics": {
-        "desc": "Synthetics Stocks",
-        "id": "b4084f29-1a7f-4058-9aac-c88b6ffdcfd1",
-        "title": "Synthetics",
-    },
-    "technical_services": {
-        "desc": "Technical Services Stocks",
-        "id": "169b9965-e311-4db4-b059-a078b7cb0353",
-        "title": "Technical Services",
-    },
-    "technical_system_software": {
-        "desc": "Technical & System Software Stocks",
-        "id": "9d3c3e2a-1e1a-4918-8649-975570c768ec",
-        "title": "Technical & System Software",
-    },
-    "technology": {
-        "desc": "Technology Stocks",
-        "id": "ca9caa2a-252f-47a8-a223-1f363f7819a3",
-        "title": "Technology",
-    },
-    "telecom_services_domestic": {
-        "desc": "Telecom Services - Domestic Stocks",
-        "id": "acf3321f-3f60-46a6-8bb5-3c3b4467feff",
-        "title": "Telecom Services - Domestic",
-    },
-    "telecom_services_foreign": {
-        "desc": "Telecom Services - Foreign Stocks",
-        "id": "c7cfc31b-b535-4b73-a11c-3c27ce920e2c",
-        "title": "Telecom Services - Foreign",
-    },
-    "textile_apparel_clothing": {
-        "desc": "Textile - Apparel Clothing Stocks",
-        "id": "cdc2c395-163a-4cb5-a16b-55e871f281d0",
-        "title": "Textile - Apparel Clothing",
-    },
-    "textile_apparel_footwear_accessories": {
-        "desc": "Textile - Apparel Footwear & Accessories Stocks",
-        "id": "e4c335b4-6caa-4e37-8061-61bddd4ffffc",
-        "title": "Textile - Apparel Footwear & Accessories",
-    },
-    "textile_industrial": {
-        "desc": "Textile Industrial Stocks",
-        "id": "fe16af89-87b5-499d-9fa9-8ef604603c95",
-        "title": "Textile Industrial",
-    },
-    "tobacco_products_other": {
-        "desc": "Tobacco Products, Other Stocks",
-        "id": "682ce320-dc78-49f9-9320-7f938587953a",
-        "title": "Tobacco Products, Other",
-    },
-    "top_energy_us": {
-        "desc": "Energy ordered by Percent Change for US region",
-        "id": "9019aa39-cffd-4ffb-8c6c-dc6e9c48ef11",
-        "title": "Top Energy US",
-    },
-    "top_etfs": {
-        "desc": "ETFs with Performance Rating of 4 & 5 ordered by Percent Change",
-        "id": "9976e04d-d1cb-49d4-abab-f8b45e0ae91c",
-        "title": "Top ETFs",
-    },
-    "top_etfs_hk": {
-        "desc": "ETFs ordered by Percent Change for HK region",
-        "id": "131fc0f0-3c7b-476d-99e3-115a91680adf",
-        "title": "Top ETFs HK",
-    },
-    "top_etfs_in": {
-        "desc": "ETFs ordered by Percent Change for IN region",
-        "id": "658effc7-8feb-4c65-9721-451e941be158",
-        "title": "Top ETFs IN",
-    },
-    "top_etfs_us": {
-        "desc": "ETFs with Performance Rating of 4 & 5 ordered by Percent Change for US region",
-        "id": "1b4ff800-e5f6-40a8-92ad-30e68a728281",
-        "title": "Top ETFs US",
-    },
-    "top_iv_options_us": {
-        "desc": "Options with Highest Implied Volatility",
-        "id": "f800f896-57a8-49f3-8763-a446d3154f13",
-        "title": "Highest Implied Volatility",
-    },
-    "top_mutual_funds": {
-        "desc": "Funds with Performance Rating of 4 & 5 ordered by Percent Change",
-        "id": "2ca6caed-e715-4fec-986a-fe68599160d9",
-        "title": "Top Mutual Funds",
-    },
-    "top_mutual_funds_au": {
-        "desc": "Funds with Performance Rating of 4 & 5 ordered by Percent Change for AU region",
-        "id": "ae9de583-95cc-4269-821f-31a6a19febae",
-        "title": "Top Mutual funds AU",
-    },
-    "top_mutual_funds_br": {
-        "desc": "Funds with Performance Rating of 4 & 5 ordered by Percent Change for BR region",
-        "id": "89d702fb-8a14-4f54-8ded-86da666a8d0b",
-        "title": "Top Mutual funds BR",
-    },
-    "top_mutual_funds_ca": {
-        "desc": "Mutual Funds ordered by Percent Change for CA region",
-        "id": "71f592c6-6dce-4508-953a-311bfe76d0bc",
-        "title": "Top Mutual Funds CA",
-    },
-    "top_mutual_funds_de": {
-        "desc": "Funds with Performance Rating of 4 & 5 ordered by Percent Change for DE region",
-        "id": "21c3ea5b-9d0d-47ef-b12c-efa620c28c7f",
-        "title": "Top Mutual funds DE",
-    },
-    "top_mutual_funds_es": {
-        "desc": "Mutual Funds ordered by Percent Change for ES region",
-        "id": "3cb76596-ccf6-4bdf-9d37-93ac03515334",
-        "title": "Top Mutual funds ES",
-    },
-    "top_mutual_funds_fr": {
-        "desc": "MutualFunds ordered by Percent Change for FR region",
-        "id": "a58a9112-738c-4c59-afc2-b5f94ea923a8",
-        "title": "Top Mutual Funds FR",
-    },
-    "top_mutual_funds_gb": {
-        "desc": "Funds with Performance Rating of 4 & 5 ordered by Percent Change for GB region",
-        "id": "8214a99f-4992-4e6a-9eab-1b68ba8124cf",
-        "title": "Top Mutual funds GB",
-    },
-    "top_mutual_funds_hk": {
-        "desc": "MutualFunds ordered by Percent Change for HK region",
-        "id": "b6e7a9e9-56d5-499b-b4af-018f45a65cd5",
-        "title": "Top Mutual Funds HK",
-    },
-    "top_mutual_funds_in": {
-        "desc": "Top Mutual funds for India",
-        "id": "1d7eb3bf-ba14-4eae-b09c-b72c772bd995",
-        "title": "Top Mutual funds for India",
-    },
-    "top_mutual_funds_it": {
-        "desc": "MutualFunds ordered by Percent Change for IT region",
-        "id": "dc43d757-d6c1-4129-bcf4-64e2fdd56472",
-        "title": "Top Mutual Funds IT",
-    },
-    "top_mutual_funds_nz": {
-        "desc": "Funds with Performance Rating of 4 & 5 ordered by Percent Change for NZ region",
-        "id": "5a740873-637d-4895-bd5e-038a0d189025",
-        "title": "Top Mutual funds NZ",
-    },
-    "top_mutual_funds_sg": {
-        "desc": "Funds with Performance Rating of 4 & 5 ordered by Percent Change for SG region",
-        "id": "c36f090e-98c0-40de-8cca-060e4d123304",
-        "title": "Top Mutual funds SG",
-    },
-    "top_mutual_funds_us": {
-        "desc": "Funds with Performance Rating of 4 & 5 ordered by Percent Change for US region",
-        "id": "b749fa8b-a782-4e64-9224-1ad76e8f3d6c",
-        "title": "Top Mutual funds US",
-    },
-    "top_options_implied_volatality": {
-        "desc": "No description",
-        "id": "671c40b0-5ea8-4063-89b9-9db45bf9edf0",
-        "title": "Highest Implied Volatility",
-    },
-    "top_options_open_interest": {
-        "desc": "Top options by Open Interest",
-        "id": "65f51cea-8dc8-4e56-9f99-6ef7720eb69c",
-        "title": "High Open Interest",
-    },
-    "toy_hobby_stores": {
-        "desc": "Toy & Hobby Stores Stocks",
-        "id": "945f763b-3ff7-4e6d-b173-25f1b72e9068",
-        "title": "Toy & Hobby Stores",
-    },
-    "toys_games": {
-        "desc": "Toys & Games Stocks",
-        "id": "b0da25c8-bde9-4390-8a07-084eb66cc388",
-        "title": "Toys & Games",
-    },
-    "trucking": {
-        "desc": "Trucking Stocks",
-        "id": "343d4ccc-e64b-4485-8802-17855e331df6",
-        "title": "Trucking",
-    },
-    "trucks_other_vehicles": {
-        "desc": "Trucks & Other Vehicles Stocks",
-        "id": "eb5abc8c-07fc-4084-bdc4-43bd8d932660",
-        "title": "Trucks & Other Vehicles",
-    },
-    "undervalued_growth_stocks": {
-        "desc": "Stocks with earnings growth rates better than 25% and relatively low PE and PEG ratios.",
-        "id": "b597175e-7243-4b42-82da-6811218a0945",
-        "title": "Undervalued Growth Stocks",
-    },
-    "undervalued_large_caps": {
-        "desc": "Large cap stocks that are potentially undervalued, ordered descending by volume",
-        "id": "e31b19b8-efe0-4ed1-8856-7715c2ef858d",
-        "title": "Potentially undervalued large cap stocks",
-    },
-    "utilities": {
-        "desc": "Utilities Stocks",
-        "id": "78dc9ee4-ca0c-488d-b3f8-83d7d72f1842",
-        "title": "Utilities",
-    },
-    "waste_management": {
-        "desc": "Waste Management Stocks",
-        "id": "a4882652-ea1f-4902-9a8b-955adcc42421",
-        "title": "Waste Management",
-    },
-    "water_utilities": {
-        "desc": "Water Utilities Stocks",
-        "id": "daaf12be-3ea2-49d2-8ac2-32aea07e0ab5",
-        "title": "Water Utilities",
-    },
-    "wireless_communications": {
-        "desc": "Wireless Communications Stocks",
-        "id": "bd92033c-f5ce-40f2-a04f-dba9cec3ab5d",
-        "title": "Wireless Communications",
-    },
+  "advertising_agencies": {
+    "desc": "Advertising Agencies Stocks",
+    "id": "b184527b-0fab-4477-b961-af240928f1cc",
+    "title": "Advertising Agencies"
+  },
+  "aerospace_defense": {
+    "desc": "Aerospace & Defense Stocks",
+    "id": "eba4a585-3a33-456e-9c68-eb79d915790d",
+    "title": "Aerospace & Defense"
+  },
+  "aggressive_small_caps": {
+    "desc": "Small cap stocks with high earnings growth rates",
+    "id": "af57f75b-eb22-4565-a604-5eb8744dd35c",
+    "title": "Aggresive small cap stocks"
+  },
+  "agricultural_inputs": {
+    "desc": "Agricultural Inputs Stocks",
+    "id": "3ca22da1-1e29-48f3-975a-6d66a9a7d952",
+    "title": "Agricultural Inputs"
+  },
+  "airlines": {
+    "desc": "Airlines Stocks",
+    "id": "a4a695cf-8fb0-4961-a82e-a353cc15ee1a",
+    "title": "Airlines"
+  },
+  "airports_air_services": {
+    "desc": "Airports & Air Services Stocks",
+    "id": "bba6400e-3d72-4a6a-a813-d91b0724a17c",
+    "title": "Airports & Air Services"
+  },
+  "all_cryptocurrencies_au": {
+    "desc": "Cryptocurrencies ordered in descending order by intraday marketcap",
+    "id": "d4146c38-dd86-418c-b043-82858b3c472d",
+    "title": "All Cryptocurrencies"
+  },
+  "all_cryptocurrencies_ca": {
+    "desc": "Cryptocurrencies ordered in descending order by intraday marketcap",
+    "id": "7d701aca-d272-4d62-8921-fbdf3a5e90cd",
+    "title": "All Cryptocurrencies"
+  },
+  "all_cryptocurrencies_eu": {
+    "desc": "Cryptocurrencies ordered in descending order by intraday marketcap",
+    "id": "56d93251-dc99-492c-b7a9-4335a103c788",
+    "title": "All Cryptocurrencies"
+  },
+  "all_cryptocurrencies_gb": {
+    "desc": "Cryptocurrencies ordered in descending order by intraday marketcap",
+    "id": "b4ee2223-1076-4666-9348-76ec467e6f05",
+    "title": "All Cryptocurrencies"
+  },
+  "all_cryptocurrencies_in": {
+    "desc": "Cryptocurrencies ordered in descending order by intraday marketcap",
+    "id": "ab1f1b1f-e355-49e2-b316-341db363f627",
+    "title": "All Cryptocurrencies"
+  },
+  "all_cryptocurrencies_us": {
+    "desc": "Cryptocurrencies ordered in descending order by intraday marketcap",
+    "id": "80046292-2898-474e-841c-7866e4f2fc80",
+    "title": "All Cryptocurrencies"
+  },
+  "aluminum": {
+    "desc": "Aluminum Stocks",
+    "id": "230d75b6-95a2-4a17-ac0e-35e4b1caca3d",
+    "title": "Aluminum"
+  },
+  "analyst_strong_buy_stocks": {
+    "desc": "Stocks with a minimum upside potential of 20% backed by an analyst's strong buy rating.",
+    "id": "704d5655-c714-47a3-a280-069b439d252b",
+    "title": "Analyst Strong Buy Stocks"
+  },
+  "apparel_manufacturing": {
+    "desc": "Apparel Manufacturing Stocks",
+    "id": "97cd324b-b40b-4723-86bd-10e058a50677",
+    "title": "Apparel Manufacturing"
+  },
+  "apparel_retail": {
+    "desc": "Apparel Retail Stocks",
+    "id": "70642ef2-5ff3-4c36-abb0-bfc11c4ccdbb",
+    "title": "Apparel Retail"
+  },
+  "asset_management": {
+    "desc": "Asset Management Stocks",
+    "id": "596c9db6-82cd-47f1-a34a-0f28d8037041",
+    "title": "Asset Management"
+  },
+  "auto_manufacturers": {
+    "desc": "Auto Manufacturers Stocks",
+    "id": "2110abca-fdda-4285-b5db-3cbae61413b5",
+    "title": "Auto Manufacturers"
+  },
+  "auto_parts": {
+    "desc": "Auto Parts Stocks",
+    "id": "8549ed2c-0b33-48f9-9c0e-bd07c39139b2",
+    "title": "Auto Parts"
+  },
+  "auto_truck_dealerships": {
+    "desc": "Auto & Truck Dealerships Stocks",
+    "id": "5b41c320-8868-4e11-9e7a-09bf625a0c59",
+    "title": "Auto & Truck Dealerships"
+  },
+  "banks_diversified": {
+    "desc": "Banks—Diversified Stocks",
+    "id": "983efda1-e27e-4900-9854-9c1acb54fdd4",
+    "title": "Banks—Diversified"
+  },
+  "banks_regional": {
+    "desc": "Banks—Regional Stocks",
+    "id": "8699101a-3199-4f9b-9431-49dcd7d7014c",
+    "title": "Banks—Regional"
+  },
+  "bearish_stocks_right_now": {
+    "desc": "Most recent stocks with a bearish technical pattern detected by Trading Central.",
+    "id": "c2670236-c8bf-459e-a470-668759e02c26",
+    "title": "Bearish Stocks Right Now"
+  },
+  "best_hist_performance_etfs": {
+    "desc": "Discover the ETFs that have performed the best over the past 5 years.",
+    "id": "698f8496-3a8b-4d9d-b2c5-6aa86923b2f6",
+    "title": "Best Historical Performance"
+  },
+  "best_hist_performance_etfs_asia": {
+    "desc": "Discover the ETFs that have performed the best over the past 5 years.",
+    "id": "82cfe7c1-9fe6-42b6-bae4-75edfe1198ef",
+    "title": "Best Historical Performance"
+  },
+  "best_hist_performance_etfs_europe": {
+    "desc": "Discover the ETFs that have performed the best over the past 5 years.",
+    "id": "392fa414-a68d-4dd2-935d-3bb00de31c14",
+    "title": "Best Historical Performance"
+  },
+  "best_hist_performance_mutual_funds": {
+    "desc": "Discover the mutual funds that have performed the best over the past 5 years.",
+    "id": "5fd3a59e-2798-4324-ac78-2fb3c8691c80",
+    "title": "Best Historical Performance"
+  },
+  "best_hist_performance_mutual_funds_asia": {
+    "desc": "Discover the mutual funds that have performed the best over the past 5 years.",
+    "id": "70b50d4d-6a67-427e-9ff5-bf62dcfcea18",
+    "title": "Best Historical Performance"
+  },
+  "best_hist_performance_mutual_funds_europe": {
+    "desc": "Discover the mutual funds that have performed the best over the past 5 years.",
+    "id": "c7bb7c3f-9c49-4bc8-9cac-3ec107e8cbfa",
+    "title": "Best Historical Performance"
+  },
+  "beverages_brewers": {
+    "desc": "Beverages—Brewers Stocks",
+    "id": "3c0198c0-4e49-4715-9ca5-393dcfdef169",
+    "title": "Beverages—Brewers"
+  },
+  "beverages_non_alcoholic": {
+    "desc": "Beverages—Non-Alcoholic Stocks",
+    "id": "1afefde6-58a3-4053-94a0-0715584463ff",
+    "title": "Beverages—Non-Alcoholic"
+  },
+  "beverages_wineries_distilleries": {
+    "desc": "Beverages—Wineries & Distilleries Stocks",
+    "id": "dc49a372-2dd8-4eb0-9107-4088f74b9237",
+    "title": "Beverages—Wineries & Distilleries"
+  },
+  "biotechnology": {
+    "desc": "Biotechnology Stocks",
+    "id": "6fed185c-ed1b-469a-916b-fc1ea70727cf",
+    "title": "Biotechnology"
+  },
+  "bond_etfs": {
+    "desc": "Discover bond-focused ETFs.",
+    "id": "ae3af3ed-c086-418a-8d2a-c689605656b4",
+    "title": "Bond ETFs"
+  },
+  "bond_mutual_funds": {
+    "desc": "Discover bond-focused mutual funds.",
+    "id": "f79d84da-3ca1-403c-ac0f-0424ee0cb33b",
+    "title": "Bond Mutual Funds"
+  },
+  "bond_mutual_funds_asia": {
+    "desc": "Discover bond-focused mutual funds.",
+    "id": "be50285c-ce13-4351-99c6-934e122cfcb4",
+    "title": "Bond Mutual Funds"
+  },
+  "bond_mutual_funds_europe": {
+    "desc": "Discover bond-focused mutual funds.",
+    "id": "9de06523-b236-4982-9f68-0e5b9895ae00",
+    "title": "Bond Mutual Funds"
+  },
+  "broadcasting": {
+    "desc": "Broadcasting Stocks",
+    "id": "46e29339-b0aa-4039-ba50-451c0670ac3a",
+    "title": "Broadcasting"
+  },
+  "building_materials": {
+    "desc": "Building Materials Stocks",
+    "id": "c1e3cbbe-c6ed-417d-ac18-b2803513f6f3",
+    "title": "Building Materials"
+  },
+  "building_products_equipment": {
+    "desc": "Building Products & Equipment Stocks",
+    "id": "7013ce43-4b66-47b3-aa34-1f0ff3cbb2f7",
+    "title": "Building Products & Equipment"
+  },
+  "bullish_stocks_right_now": {
+    "desc": "Most recent stocks with a bullish technical pattern detected by Trading Central.",
+    "id": "663e975d-9bf1-424a-9ce1-634cea6648d6",
+    "title": "Bullish Stocks Right Now"
+  },
+  "business_equipment_supplies": {
+    "desc": "Business Equipment & Supplies Stocks",
+    "id": "c224f924-ccd6-4423-b45d-118e7d597161",
+    "title": "Business Equipment & Supplies"
+  },
+  "capital_markets": {
+    "desc": "Capital Markets Stocks",
+    "id": "d4dc9b04-79ed-4cb9-b3a8-67c9f5c93e2e",
+    "title": "Capital Markets"
+  },
+  "cheapest_etfs": {
+    "desc": "Uncover ETFs which report the cheapest Annual Net Expense Ratio.",
+    "id": "609681e0-857e-4168-9944-d2afa7a5e3eb",
+    "title": "Cheapest ETFs"
+  },
+  "cheapest_etfs_asia": {
+    "desc": "Uncover ETFs which report the cheapest Annual Net Expense Ratio.",
+    "id": "612e4c2f-83cc-45d6-80d1-b851d3916e4f",
+    "title": "Cheapest ETFs"
+  },
+  "cheapest_etfs_europe": {
+    "desc": "Uncover ETFs which report the cheapest Annual Net Expense Ratio.",
+    "id": "93ce8617-984a-4bec-9256-4c832fff8ceb",
+    "title": "Cheapest ETFs"
+  },
+  "cheapest_mutual_funds": {
+    "desc": "Uncover mutual funds which report the cheapest Annual Net Expense Ratio.",
+    "id": "e0467260-410a-49c0-9320-da5fbf2a3e73",
+    "title": "Cheapest Mutual Funds"
+  },
+  "cheapest_mutual_funds_asia": {
+    "desc": "Uncover mutual funds which report the cheapest Annual Net Expense Ratio.",
+    "id": "e0cdbbb3-6a87-4e1b-82c6-ae5d4eb40bb1",
+    "title": "Cheapest Mutual Funds"
+  },
+  "cheapest_mutual_funds_europe": {
+    "desc": "Uncover mutual funds which report the cheapest Annual Net Expense Ratio.",
+    "id": "d63697a6-2488-42f1-8471-90d564f95fee",
+    "title": "Cheapest Mutual Funds"
+  },
+  "chemicals": {
+    "desc": "Chemicals Stocks",
+    "id": "78341de7-2e70-4ff0-9347-d23c731bd87f",
+    "title": "Chemicals"
+  },
+  "coking_coal": {
+    "desc": "Coking Coal Stocks",
+    "id": "165835db-e7c6-4c17-8fce-e5e6829105c7",
+    "title": "Coking Coal"
+  },
+  "commodity_etfs": {
+    "desc": "Discover commodity-focused ETFs.",
+    "id": "6ab335b4-61e8-4d88-86a6-30f1c6c94fa7",
+    "title": "Commodity ETFs"
+  },
+  "commodity_etfs_asia": {
+    "desc": "Discover commodity-focused ETFs.",
+    "id": "f5658ccd-911e-4490-b4c4-78c2dad9ae83",
+    "title": "Commodity ETFs"
+  },
+  "commodity_etfs_europe": {
+    "desc": "Discover commodity-focused ETFs.",
+    "id": "9491c51d-3b6f-48ca-8a6d-6236ee092433",
+    "title": "Commodity ETFs"
+  },
+  "commodity_mutual_funds": {
+    "desc": "Discover commodity-focused mutual funds.",
+    "id": "ca67a1b3-572c-433c-b1a4-a0da3738fc14",
+    "title": "Commodity Metal Mutual Funds"
+  },
+  "communication_equipment": {
+    "desc": "Communication Equipment Stocks",
+    "id": "b750cbb5-d76b-4786-9ec8-ad6ca68a26b8",
+    "title": "Communication Equipment"
+  },
+  "community_sentiment_most_bearish": {
+    "desc": "Community Sentiment Most Bearish",
+    "id": "772fad60-f176-4333-ac4a-af8de320e277",
+    "title": "Community Sentiment Most Bearish"
+  },
+  "community_sentiment_most_bullish": {
+    "desc": "Community Sentiment Most Bullish",
+    "id": "0e85bb19-703c-44a3-b3a3-e9febb3e07e4",
+    "title": "Community Sentiment Most Bullish"
+  },
+  "computer_hardware": {
+    "desc": "Computer Hardware Stocks",
+    "id": "0f691c9d-a971-4a36-936f-9135f87ff6f0",
+    "title": "Computer Hardware"
+  },
+  "confectioners": {
+    "desc": "Confectioners Stocks",
+    "id": "66e04ede-6ddd-4cf5-b3f0-b25666495296",
+    "title": "Confectioners"
+  },
+  "conglomerates": {
+    "desc": "Conglomerates Stocks",
+    "id": "a54ed4a5-cc92-4171-9bc7-24ce06ad5b4f",
+    "title": "Conglomerates"
+  },
+  "conservative_foreign_funds": {
+    "desc": "Foreign funds with Performance Rating of 4 & 5, low risk and top-half returns",
+    "id": "86de34fe-ba77-4c36-be03-19c5d7cf4462",
+    "title": "Conservative Foreign Funds"
+  },
+  "consulting_services": {
+    "desc": "Consulting Services Stocks",
+    "id": "2f05d6e4-7b4d-44e0-9e25-4bc8ad1011fb",
+    "title": "Consulting Services"
+  },
+  "consumer_electronics": {
+    "desc": "Consumer Electronics Stocks",
+    "id": "f4cc7ac5-4c1a-40e5-9271-1e8c59a29bfa",
+    "title": "Consumer Electronics"
+  },
+  "copper": {
+    "desc": "Copper Stocks",
+    "id": "657a2af8-2b4f-4f10-9f36-1e9e14f3aab4",
+    "title": "Copper"
+  },
+  "credit_services": {
+    "desc": "Credit Services Stocks",
+    "id": "08680af3-e653-43a4-b704-b87a20c6716b",
+    "title": "Credit Services"
+  },
+  "day_gainers": {
+    "desc": "Discover the equities with the greatest gains in the trading day.",
+    "id": "ec5bebb9-b7b2-4474-9e5c-3e258b61cbe6",
+    "title": "Day Gainers"
+  },
+  "day_gainers_americas": {
+    "desc": "stocks ordered in descending order by price percent change greater than 3% with respect to the previous close",
+    "id": "0bfef98d-1a4b-449a-9049-737656446e7c",
+    "title": "Day Gainers Americas"
+  },
+  "day_gainers_asia": {
+    "desc": "Discover the equities with the greatest gains in the trading day.",
+    "id": "fe852975-302e-413a-bd9c-7a2d602645e9",
+    "title": "Day Gainers"
+  },
+  "day_gainers_au": {
+    "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for Australia",
+    "id": "d0907194-0b84-44d8-8005-054546c8f66b",
+    "title": "Day Gainers - Australia"
+  },
+  "day_gainers_br": {
+    "desc": "Stocks ordered in descending order by price percent change greater than 3% with respect to the previous close",
+    "id": "8fd79848-c838-46bc-986c-7b97414e7d76",
+    "title": "Day Gainers - Brazil"
+  },
+  "day_gainers_ca": {
+    "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for Canada",
+    "id": "4a047ba4-ba4e-4372-8327-202083a89057",
+    "title": "Day Gainers - Canada"
+  },
+  "day_gainers_cryptocurrencies": {
+    "desc": "Discover the cryptocurrencies with the greatest gains in the last 24 hours.",
+    "id": "79c584ec-a1bc-443a-9330-272abd5f696c",
+    "title": "Day Gainers"
+  },
+  "day_gainers_de": {
+    "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for Germany",
+    "id": "62764a5a-a47b-4a0d-b72a-f454e7b8acfb",
+    "title": "Day Gainers - Germany"
+  },
+  "day_gainers_dji": {
+    "desc": "Day Gainers - Dow Jones Industrials",
+    "id": "9e621bd5-9a7e-4d00-869d-1b1e1b05afd0",
+    "title": "Day Gainers - Dow Jones Industrials"
+  },
+  "day_gainers_es": {
+    "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for Spain",
+    "id": "c50cfd23-75cc-4549-8c57-5029e10f962c",
+    "title": "Day Gainers - Spain"
+  },
+  "day_gainers_etfs": {
+    "desc": "Discover the ETFs with the greatest gains in the trading day.",
+    "id": "2249f0f3-2844-4541-9e6d-3d78527388e2",
+    "title": "Day Gainers"
+  },
+  "day_gainers_etfs_asia": {
+    "desc": "Discover the ETFs with the greatest gains in the trading day.",
+    "id": "c80798fa-27bc-4a09-93c8-2aee34dd5f1f",
+    "title": "Day Gainers"
+  },
+  "day_gainers_etfs_europe": {
+    "desc": "Discover the ETFs with the greatest gains in the trading day.",
+    "id": "774befd7-6ffe-4f5b-83ed-3aeb8be8b161",
+    "title": "Day Gainers"
+  },
+  "day_gainers_europe": {
+    "desc": "Discover the equities with the greatest gains in the trading day.",
+    "id": "43463575-8b42-4762-9d7e-705588a25dcd",
+    "title": "Day Gainers"
+  },
+  "day_gainers_fr": {
+    "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for France",
+    "id": "9b598d0d-18d5-406e-a807-98d3e63c6afb",
+    "title": "Day Gainers - France"
+  },
+  "day_gainers_gb": {
+    "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for United Kingdom",
+    "id": "97b9075b-c5ab-4c85-bfd3-9694a061e5d2",
+    "title": "Day Gainers - United Kingdom"
+  },
+  "day_gainers_hk": {
+    "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for Hong Kong",
+    "id": "93505957-f2ce-4666-8f7c-91275819b5f6",
+    "title": "Day Gainers - Hong Kong"
+  },
+  "day_gainers_in": {
+    "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for India",
+    "id": "134b914f-e393-4b2e-a824-b4be15517cd8",
+    "title": "Day Gainers - India"
+  },
+  "day_gainers_it": {
+    "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for Italy",
+    "id": "9c86c7ac-c474-40d9-8912-1906cfc6cc1c",
+    "title": "Day Gainers - Italy"
+  },
+  "day_gainers_mutual_funds": {
+    "desc": "Discover the mutual funds with the greatest gains in the trading day.",
+    "id": "3f7601e3-e6c6-49fa-863b-7dc58dc325b0",
+    "title": "Day Gainers"
+  },
+  "day_gainers_mutual_funds_asia": {
+    "desc": "Discover the mutual funds with the greatest gains in the trading day.",
+    "id": "ce6aa148-51d9-4652-bddb-92265276eca4",
+    "title": "Day Gainers"
+  },
+  "day_gainers_mutual_funds_europe": {
+    "desc": "Discover the mutual funds with the greatest gains in the trading day.",
+    "id": "f2b8b8f0-cf13-4e5a-8222-e39d8b1d1c47",
+    "title": "Day Gainers"
+  },
+  "day_gainers_ndx": {
+    "desc": "Day Gainers - NASDAQ 100",
+    "id": "d1d6e2ab-ca6f-4a7d-a2f2-d872efc816ef",
+    "title": "Day Gainers - NASDAQ 100"
+  },
+  "day_gainers_nz": {
+    "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for New Zealand",
+    "id": "faa6cfcd-cb5d-4dfc-8532-3692ee3cc359",
+    "title": "Day Gainers - New Zealand"
+  },
+  "day_gainers_options": {
+    "desc": "Discover the options with the greatest gains in the trading day.",
+    "id": "39bfd52b-6f5f-40a1-bcc8-31a9728277d8",
+    "title": "Day Gainers"
+  },
+  "day_gainers_sg": {
+    "desc": "Stocks ordered in descending order by price percent change greater than 2.5% with respect to the previous close for Singapore",
+    "id": "4d834f86-c0a9-4211-b7a4-3290011892eb",
+    "title": "Day Gainers - Singapore"
+  },
+  "day_losers": {
+    "desc": "Discover the equities with the greatest losses in the trading day.",
+    "id": "8ecefa87-a8b0-434a-9b39-e061a0baef9b",
+    "title": "Day Losers"
+  },
+  "day_losers_americas": {
+    "desc": "stocks ordered in ascending order by price percent change lesser than 2.5% with respect to the previous close",
+    "id": "0e35eb9f-8cf1-4661-a336-e996c1c6f7f8",
+    "title": "Day Losers Americas"
+  },
+  "day_losers_asia": {
+    "desc": "Discover the equities with the greatest losses in the trading day.",
+    "id": "37df3812-b9ee-41f0-87e4-b5f893f3198d",
+    "title": "Day Losers"
+  },
+  "day_losers_au": {
+    "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for Australia",
+    "id": "e8e6731f-0eb9-4377-829c-1f61cb670df4",
+    "title": "Day Losers - Australia"
+  },
+  "day_losers_br": {
+    "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for Brazil",
+    "id": "2dd8e3c9-8755-4d02-9bf3-0dd0640d38f2",
+    "title": "Day Losers - Brazil"
+  },
+  "day_losers_ca": {
+    "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for Canada",
+    "id": "44c0eb22-33f1-4bf9-b4d0-e940838b47f5",
+    "title": "Day Losers - Canada"
+  },
+  "day_losers_cryptocurrencies": {
+    "desc": "Discover the cryptocurrencies with the greatest losses in the last 24 hours.",
+    "id": "97d663ee-cf91-4f53-8cfa-0b8b580d0b11",
+    "title": "Day Losers"
+  },
+  "day_losers_de": {
+    "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for Germany",
+    "id": "953e5166-b2b3-471c-a765-4c1c3c15b2da",
+    "title": "Day Losers - Germany"
+  },
+  "day_losers_dji": {
+    "desc": "Day Losers - Dow Jones Industrials",
+    "id": "c95c79eb-8b89-461b-b4cf-680cf77f057e",
+    "title": "Day Losers - Dow Jones Industrials"
+  },
+  "day_losers_es": {
+    "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for Spain",
+    "id": "80678708-0b02-409b-a378-15965a930d60",
+    "title": "Day Losers - Spain"
+  },
+  "day_losers_etfs": {
+    "desc": "Discover the ETFs with the greatest losses in the trading day.",
+    "id": "d9faac27-b9ef-4f48-be58-6a6549af840f",
+    "title": "Day Losers"
+  },
+  "day_losers_etfs_asia": {
+    "desc": "Discover the ETFs with the greatest losses in the trading day.",
+    "id": "b3439e46-5d04-42c3-8780-4bc4a067bfb9",
+    "title": "Day Losers"
+  },
+  "day_losers_etfs_europe": {
+    "desc": "Discover the ETFs with the greatest losses in the trading day.",
+    "id": "dbe39476-0b84-4333-a1dd-179bd9723a17",
+    "title": "Day Losers"
+  },
+  "day_losers_europe": {
+    "desc": "Discover the equities with the greatest losses in the trading day.",
+    "id": "3dfde79b-6160-4da3-a042-d1a86fd5eff9",
+    "title": "Day Losers"
+  },
+  "day_losers_fr": {
+    "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for France",
+    "id": "bb9aaa7a-935e-49de-999e-e5b86c9aeefa",
+    "title": "Day Losers - France"
+  },
+  "day_losers_gb": {
+    "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for United Kingdom",
+    "id": "01a3b7ec-c577-401f-8b19-57d6bbf5ce8e",
+    "title": "Day Losers - United Kingdom"
+  },
+  "day_losers_hk": {
+    "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for Hong Kong",
+    "id": "5d940688-4853-49bd-a3b3-849ca743ad8c",
+    "title": "Day Losers - Hong Kong"
+  },
+  "day_losers_in": {
+    "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for India",
+    "id": "d17726f5-6c05-4c80-9cc9-3578febcdb3c",
+    "title": "Day Losers - India"
+  },
+  "day_losers_it": {
+    "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for Italy",
+    "id": "46677e46-895d-4c5c-a938-577d80df2180",
+    "title": "Day Losers - Italy"
+  },
+  "day_losers_mutual_funds": {
+    "desc": "Discover the mutual funds with the greatest losses in the trading day.",
+    "id": "3e144242-9d1d-48fe-8426-da808ffe6014",
+    "title": "Day Losers"
+  },
+  "day_losers_mutual_funds_asia": {
+    "desc": "Discover the mutual funds with the greatest losses in the trading day.",
+    "id": "988e04b3-7de5-4cee-8665-46182721f9f5",
+    "title": "Day Losers"
+  },
+  "day_losers_mutual_funds_europe": {
+    "desc": "Discover the mutual funds with the greatest losses in the trading day.",
+    "id": "26340ece-9f3b-47aa-ac23-e695b7021a20",
+    "title": "Day Losers"
+  },
+  "day_losers_ndx": {
+    "desc": "Day Losers - NASDAQ 100",
+    "id": "b72e29e8-dfc2-428e-ab3f-e69df2008457",
+    "title": "Day Losers - NASDAQ 100"
+  },
+  "day_losers_nz": {
+    "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for New Zealand",
+    "id": "ce6dcbd1-c853-402a-90b4-776865c76f5d",
+    "title": "Day Losers - New Zealand"
+  },
+  "day_losers_options": {
+    "desc": "Discover the options with the greatest losses in the trading day.",
+    "id": "ebfe7fdb-1aa8-4350-9308-899e49bd307a",
+    "title": "Day Losers"
+  },
+  "day_losers_sg": {
+    "desc": "Stocks ordered in ascending order by price percent change with respect to the previous close for Singapore",
+    "id": "87813bf9-1d84-4d03-9552-d5ee38666ca4",
+    "title": "Day Losers - Singapore"
+  },
+  "department_stores": {
+    "desc": "Department Stores Stocks",
+    "id": "b5c6a46b-d791-4fa2-a293-46c603515959",
+    "title": "Department Stores"
+  },
+  "diagnostics_research": {
+    "desc": "Diagnostics & Research Stocks",
+    "id": "c77f59d3-f26f-43ce-a844-1bc8115257e6",
+    "title": "Diagnostics & Research"
+  },
+  "discount_stores": {
+    "desc": "Discount Stores Stocks",
+    "id": "9dd246ea-0929-4836-aef2-075e4df38087",
+    "title": "Discount Stores"
+  },
+  "drug_manufacturers_general": {
+    "desc": "Drug Manufacturers—General Stocks",
+    "id": "264a8d31-3229-483a-924b-9660bf869f32",
+    "title": "Drug Manufacturers—General"
+  },
+  "drug_manufacturers_specialty_generic": {
+    "desc": "Drug Manufacturers—Specialty & Generic Stocks",
+    "id": "4b782d93-7013-4184-bdd5-61b770c33059",
+    "title": "Drug Manufacturers—Specialty & Generic"
+  },
+  "education_training_services": {
+    "desc": "Education & Training Services Stocks",
+    "id": "0f996a22-ccbf-43ff-81fa-d1c1e4a003c1",
+    "title": "Education & Training Services"
+  },
+  "electrical_equipment_parts": {
+    "desc": "Electrical Equipment & Parts Stocks",
+    "id": "ab10085a-581b-46f5-9950-c663b63414d2",
+    "title": "Electrical Equipment & Parts"
+  },
+  "electronic_components": {
+    "desc": "Electronic Components Stocks",
+    "id": "9a59374c-9f17-45bc-b60f-fde16cd9dd00",
+    "title": "Electronic Components"
+  },
+  "electronic_gaming_multimedia": {
+    "desc": "Electronic Gaming & Multimedia Stocks",
+    "id": "8941e1e5-baf7-407b-8015-926ae079241e",
+    "title": "Electronic Gaming & Multimedia"
+  },
+  "electronics_computer_distribution": {
+    "desc": "Electronics & Computer Distribution Stocks",
+    "id": "917e3a6a-04e3-45bc-96c2-f13a384965c4",
+    "title": "Electronics & Computer Distribution"
+  },
+  "engineering_construction": {
+    "desc": "Engineering & Construction Stocks",
+    "id": "826440a9-075c-483a-9f49-5c088317d8b5",
+    "title": "Engineering & Construction"
+  },
+  "entertainment": {
+    "desc": "Entertainment Stocks",
+    "id": "95861fa9-815d-456b-8057-7ba3be5fd3c8",
+    "title": "Entertainment"
+  },
+  "equity_mutual_funds": {
+    "desc": "Discover mutual funds which are made up of at least 70% equities.",
+    "id": "b3c7923a-b55e-40bc-b4b8-3d92dc3c6bfe",
+    "title": "Equity Mutual Funds"
+  },
+  "farm_heavy_construction_machinery": {
+    "desc": "Farm & Heavy Construction Machinery Stocks",
+    "id": "41805c11-aedb-4e23-8fed-50a6a543cea4",
+    "title": "Farm & Heavy Construction Machinery"
+  },
+  "farm_products": {
+    "desc": "Farm Products Stocks",
+    "id": "11692c0c-3cbe-46cc-87a6-70fb77c65723",
+    "title": "Farm Products"
+  },
+  "fifty_two_wk_gainers": {
+    "desc": "Discover the equities with the greatest gains in the last 52 weeks.",
+    "id": "2958f760-5f00-4e7d-97be-d2d75d161e24",
+    "title": "52-Week Gainers"
+  },
+  "fifty_two_wk_gainers_asia": {
+    "desc": "Discover the equities with the greatest gains in the last 52 weeks.",
+    "id": "ac6e41c4-2901-4e5a-9305-58f87babb48d",
+    "title": "52-Week Gainers"
+  },
+  "fifty_two_wk_gainers_cryptocurrencies": {
+    "desc": "Discover the cryptocurrencies with the greatest gains in the last 52 weeks.",
+    "id": "d3a99fd0-1ff6-4307-a25b-a05678704f25",
+    "title": "52-Week Gainers"
+  },
+  "fifty_two_wk_gainers_etfs": {
+    "desc": "Discover the ETFs with the greatest gains in the last 52 weeks.",
+    "id": "2a262fab-c342-4653-9c4b-14728b7bceab",
+    "title": "52-Week Gainers"
+  },
+  "fifty_two_wk_gainers_etfs_asia": {
+    "desc": "Discover the ETFs with the greatest gains in the last 52 weeks.",
+    "id": "cfb86eb7-0e2e-40e4-b2a9-2a63e2b59a2f",
+    "title": "52-Week Gainers"
+  },
+  "fifty_two_wk_gainers_etfs_europe": {
+    "desc": "Discover the ETFs with the greatest gains in the last 52 weeks.",
+    "id": "69a6b655-f3c9-45b0-a28d-9077661c7c04",
+    "title": "52-Week Gainers"
+  },
+  "fifty_two_wk_gainers_europe": {
+    "desc": "Discover the equities with the greatest gains in the last 52 weeks.",
+    "id": "ae4ff65c-3cf1-48ea-aa10-de00472d0e30",
+    "title": "52-Week Gainers"
+  },
+  "fifty_two_wk_gainers_mutual_funds": {
+    "desc": "Discover the mutual funds with the greatest gains in the last 52 weeks.",
+    "id": "5cad2dcc-0ec1-4c97-bc72-0244e3c2bbdf",
+    "title": "52-Week Gainers"
+  },
+  "fifty_two_wk_gainers_mutual_funds_asia": {
+    "desc": "Discover the mutual funds with the greatest gains in the last 52 weeks.",
+    "id": "c162235a-4624-4301-849f-c34c40d7b7cc",
+    "title": "52-Week Gainers"
+  },
+  "fifty_two_wk_gainers_mutual_funds_europe": {
+    "desc": "Discover the mutual funds with the greatest gains in the last 52 weeks.",
+    "id": "38bac306-de8a-4ae4-858f-0f959e1ea961",
+    "title": "52-Week Gainers"
+  },
+  "fifty_two_wk_losers": {
+    "desc": "Discover the equities with the greatest losses in the last 52 weeks.",
+    "id": "5176dd5b-d919-4d85-a687-c71326d2de92",
+    "title": "52-Week Losers"
+  },
+  "fifty_two_wk_losers_asia": {
+    "desc": "Discover the equities with the greatest losses in the last 52 weeks.",
+    "id": "1417ea6b-99c2-4bcd-8956-57a43da68646",
+    "title": "52-Week Losers"
+  },
+  "fifty_two_wk_losers_cryptocurrencies": {
+    "desc": "Discover the cryptocurrencies with the greatest losses in the last 52 weeks.",
+    "id": "6248a532-2d42-4a05-bbb8-ee745f3aaee8",
+    "title": "52-Week Losers"
+  },
+  "fifty_two_wk_losers_etfs": {
+    "desc": "Discover the ETFs with the greatest losses in the last 52 weeks.",
+    "id": "23ce67d2-e283-4fbe-ab5b-089102afe9e2",
+    "title": "52-Week Losers"
+  },
+  "fifty_two_wk_losers_etfs_asia": {
+    "desc": "Discover the ETFs with the greatest losses in the last 52 weeks.",
+    "id": "85d56d74-8e28-442e-b0fb-51cb75691270",
+    "title": "52-Week Losers"
+  },
+  "fifty_two_wk_losers_etfs_europe": {
+    "desc": "Discover the ETFs with the greatest losses in the last 52 weeks.",
+    "id": "758ee256-c89f-4f6c-bac6-7cccb13d7f40",
+    "title": "52-Week Losers"
+  },
+  "fifty_two_wk_losers_europe": {
+    "desc": "Discover the equities with the greatest losses in the last 52 weeks.",
+    "id": "de97db3f-6b73-4b0c-b85a-1279d4079d93",
+    "title": "52-Week Losers"
+  },
+  "fifty_two_wk_losers_mutual_funds": {
+    "desc": "Discover the mutual funds with the greatest losses in the last 52 weeks.",
+    "id": "d0d2d56f-0b6d-48fe-a1cd-e3063ee14132",
+    "title": "52-Week Losers"
+  },
+  "fifty_two_wk_losers_mutual_funds_asia": {
+    "desc": "Discover the mutual funds with the greatest losses in the last 52 weeks.",
+    "id": "02f70157-2018-4b44-9ee7-3f8e5201d402",
+    "title": "52-Week Losers"
+  },
+  "fifty_two_wk_losers_mutual_funds_europe": {
+    "desc": "Discover the mutual funds with the greatest losses in the last 52 weeks.",
+    "id": "27dc6a8b-1ac0-4a5e-87d0-dcaa4160d0e5",
+    "title": "52-Week Losers"
+  },
+  "financial_conglomerates": {
+    "desc": "Financial Conglomerates Stocks",
+    "id": "3d48d904-53ab-456a-ba55-020be6a82445",
+    "title": "Financial Conglomerates"
+  },
+  "financial_data_stock_exchanges": {
+    "desc": "Financial Data & Stock Exchanges Stocks",
+    "id": "c42b137d-6d9c-4c16-8822-49b74ffcf8ec",
+    "title": "Financial Data & Stock Exchanges"
+  },
+  "food_distribution": {
+    "desc": "Food Distribution Stocks",
+    "id": "e5e6e726-58d0-4080-bce2-812854ab3d87",
+    "title": "Food Distribution"
+  },
+  "footwear_accessories": {
+    "desc": "Footwear & Accessories Stocks",
+    "id": "fdc83b05-5a96-4e33-aa85-51191ca69295",
+    "title": "Footwear & Accessories"
+  },
+  "furnishings_fixtures_appliances": {
+    "desc": "Furnishings, Fixtures & Appliances Stocks",
+    "id": "71710d80-fd39-4ba1-96b4-df8826e2f91f",
+    "title": "Furnishings, Fixtures & Appliances"
+  },
+  "gambling": {
+    "desc": "Gambling Stocks",
+    "id": "189dfab8-6cd6-4838-a13a-c3551c6ae0b2",
+    "title": "Gambling"
+  },
+  "gold": {
+    "desc": "Gold Stocks",
+    "id": "f5d2411d-4fe6-4904-867e-f01ce9b99740",
+    "title": "Gold"
+  },
+  "grocery_stores": {
+    "desc": "Grocery Stores Stocks",
+    "id": "92b77f75-05ee-4662-93cc-60002d8b7a63",
+    "title": "Grocery Stores"
+  },
+  "growth_technology_stocks": {
+    "desc": "Technology stocks with revenue and earnings growth in excess of 25%.",
+    "id": "e0c43708-7fa1-4f02-9425-697c0443d32f",
+    "title": "Growth Technology Stocks"
+  },
+  "health_information_services": {
+    "desc": "Health Information Services Stocks",
+    "id": "efaac38f-c789-4a6a-92ec-111077f4af8a",
+    "title": "Health Information Services"
+  },
+  "healthcare_plans": {
+    "desc": "Healthcare Plans Stocks",
+    "id": "33d768c1-5f65-4896-89ed-d8e7d001c9b8",
+    "title": "Healthcare Plans"
+  },
+  "high_growth_large_etfs": {
+    "desc": "Discover large cap, high growth-focused ETFs.",
+    "id": "092168ea-b0c5-4361-b509-7a3289bcb9d2",
+    "title": "High growth, Large ETFs"
+  },
+  "high_growth_large_mutual_funds": {
+    "desc": "Discover large cap, high growth-focused mutual funds.",
+    "id": "fd0425d1-a9f6-491a-9320-fd37995fbaba",
+    "title": "High Growth, Large Mutual Funds"
+  },
+  "high_yield_bond": {
+    "desc": "High Yield Bond with Performance Rating of 4 & 5, low risk and top-half returns",
+    "id": "d675527c-bc6a-486c-872d-bca43fbb4322",
+    "title": "High Yield Bond"
+  },
+  "high_yield_high_return": {
+    "desc": "As popularized by strategies like Greenblatt's Magic Formula, uncover quality equities with a high earnings yield and return on capital.",
+    "id": "f6ae7898-0c88-489e-897f-b1fc42e211cb",
+    "title": "High Yield, High Return"
+  },
+  "high_yield_high_return_asia": {
+    "desc": "As popularized by strategies like Greenblatt's Magic Formula, uncover quality equities with a high earnings yield and return on capital.",
+    "id": "2e35021d-b56b-4b02-b07a-1174042c4add",
+    "title": "High Yield, High Return"
+  },
+  "high_yield_high_return_europe": {
+    "desc": "As popularized by strategies like Greenblatt's Magic Formula, uncover quality equities with a high earnings yield and return on capital.",
+    "id": "096683a2-e083-4a21-8203-9c4ac116db01",
+    "title": "High Yield, High Return"
+  },
+  "home_improvement_retail": {
+    "desc": "Home Improvement Retail Stocks",
+    "id": "13803724-428d-4fbe-8825-012987d3bdd2",
+    "title": "Home Improvement Retail"
+  },
+  "household_personal_products": {
+    "desc": "Household & Personal Products Stocks",
+    "id": "4b2d4303-6233-41e4-ae0c-ffec11fa34f0",
+    "title": "Household & Personal Products"
+  },
+  "industrial_distribution": {
+    "desc": "Industrial Distribution Stocks",
+    "id": "3a920780-96d6-44d0-87b9-6946886286d8",
+    "title": "Industrial Distribution"
+  },
+  "information_technology_services": {
+    "desc": "Information Technology Services Stocks",
+    "id": "b3631428-79da-4b51-a689-1dc4bf80aec2",
+    "title": "Information Technology Services"
+  },
+  "infrastructure_operations": {
+    "desc": "Infrastructure Operations Stocks",
+    "id": "04696a3f-8c50-48d6-919d-6cde073cac0d",
+    "title": "Infrastructure Operations"
+  },
+  "insurance_brokers": {
+    "desc": "Insurance Brokers Stocks",
+    "id": "d1d36030-5858-4e02-a955-f8b9271e20aa",
+    "title": "Insurance Brokers"
+  },
+  "insurance_diversified": {
+    "desc": "Insurance—Diversified Stocks",
+    "id": "1081c88c-1be2-4f26-a435-ac87883e9ddd",
+    "title": "Insurance—Diversified"
+  },
+  "insurance_life": {
+    "desc": "Insurance—Life Stocks",
+    "id": "da5f094b-418c-4649-8aa1-9bc4ee3d4ca3",
+    "title": "Insurance—Life"
+  },
+  "insurance_property_casualty": {
+    "desc": "Insurance—Property & Casualty Stocks",
+    "id": "b64e6ae9-0b59-4141-921a-2f1bec699e18",
+    "title": "Insurance—Property & Casualty"
+  },
+  "insurance_reinsurance": {
+    "desc": "Insurance—Reinsurance Stocks",
+    "id": "5c932600-a02c-493a-b865-c101c945b388",
+    "title": "Insurance—Reinsurance"
+  },
+  "insurance_specialty": {
+    "desc": "Insurance—Specialty Stocks",
+    "id": "941a8783-8f96-42a1-82ea-a30a60dd704d",
+    "title": "Insurance—Specialty"
+  },
+  "integrated_freight_logistics": {
+    "desc": "Integrated Freight & Logistics Stocks",
+    "id": "7e94aa31-e0fd-4bba-9c01-a4d1fcd80ff6",
+    "title": "Integrated Freight & Logistics"
+  },
+  "internet_content_information": {
+    "desc": "Internet Content & Information Stocks",
+    "id": "92fa63be-f396-43f0-a1d0-93cb109d1b8f",
+    "title": "Internet Content & Information"
+  },
+  "internet_retail": {
+    "desc": "Internet Retail Stocks",
+    "id": "9573ad47-1820-4a52-b244-ddc0edc0db1c",
+    "title": "Internet Retail"
+  },
+  "large_blend_etfs": {
+    "desc": "Discover the ETFs with a mix of large cap growth and value stocks.",
+    "id": "03b61465-e574-4100-b0ba-508ad235c061",
+    "title": "Large Blend"
+  },
+  "large_blend_mutual_funds": {
+    "desc": "Discover the mutual funds with a mix of large cap growth and value stocks.",
+    "id": "7338519d-5dbc-4609-9ab6-627d58253a8a",
+    "title": "Large Blend"
+  },
+  "largest_market_cap": {
+    "desc": "Uncover the equities with the largest market cap.",
+    "id": "e6e3b1e2-65bc-48a1-8274-a06676f3f969",
+    "title": "Largest Market Cap"
+  },
+  "largest_market_cap_asia": {
+    "desc": "Uncover the equities with the largest market cap.",
+    "id": "ad808afe-47db-4905-9bd4-086032bda47f",
+    "title": "Largest Market Cap"
+  },
+  "largest_market_cap_cryptocurrencies": {
+    "desc": "Uncover the crypto with the largest market cap.",
+    "id": "e8ec0193-36cb-4b26-aeba-2eb087fb4b79",
+    "title": "Largest Market Cap"
+  },
+  "largest_market_cap_europe": {
+    "desc": "Uncover the equities with the largest market cap.",
+    "id": "504528d9-365f-4f97-ad08-7240eddd2bef",
+    "title": "Largest Market Cap"
+  },
+  "latest_analyst_upgraded_stocks": {
+    "desc": "Most recent stocks that get upgraded by an Analyst.",
+    "id": "54e61871-8def-46d5-8b71-75baeff8cc89",
+    "title": "Latest Analyst Upgraded Stocks"
+  },
+  "leisure": {
+    "desc": "Leisure Stocks",
+    "id": "fd998bdb-54a6-4352-81c7-3aa40f9b4b81",
+    "title": "Leisure"
+  },
+  "lodging": {
+    "desc": "Lodging Stocks",
+    "id": "af876331-70bf-4cea-8a03-6bb40877e689",
+    "title": "Lodging"
+  },
+  "low_risk_mutual_funds": {
+    "desc": "Discover the mutual funds with Morningstar Risk Rating of 4 and 5, likely indicating lower risk.",
+    "id": "e065a28e-65e3-49ee-8c38-54be12b0db97",
+    "title": "Low Risk Mutual Funds"
+  },
+  "low_risk_mutual_funds_asia": {
+    "desc": "Discover the mutual funds with Morningstar Risk Rating of 4 and 5, likely indicating lower risk.",
+    "id": "9e00c0b2-b1f0-4b22-9de6-d76f2d58179a",
+    "title": "Low Risk Mutual Funds"
+  },
+  "low_risk_mutual_funds_europe": {
+    "desc": "Discover the mutual funds with Morningstar Risk Rating of 4 and 5, likely indicating lower risk.",
+    "id": "3b7b021e-1248-457f-874a-efe78018dcb7",
+    "title": "Low Risk Mutual Funds"
+  },
+  "lumber_wood_production": {
+    "desc": "Lumber & Wood Production Stocks",
+    "id": "6e3842f8-1918-4fa2-a4a4-a3245690515a",
+    "title": "Lumber & Wood Production"
+  },
+  "luxury_goods": {
+    "desc": "Luxury Goods Stocks",
+    "id": "47e6d361-29f2-4e41-b66d-9aeaba30e821",
+    "title": "Luxury Goods"
+  },
+  "marine_shipping": {
+    "desc": "Marine Shipping Stocks",
+    "id": "410de1b4-f066-48f4-bc67-72c9731c78ce",
+    "title": "Marine Shipping"
+  },
+  "medical_care_facilities": {
+    "desc": "Medical Care Facilities Stocks",
+    "id": "819f5f80-ec31-4b5a-97ac-d6efed328ccb",
+    "title": "Medical Care Facilities"
+  },
+  "medical_devices": {
+    "desc": "Medical Devices Stocks",
+    "id": "2865489f-9a23-489f-8545-c6e1ad7bcdfc",
+    "title": "Medical Devices"
+  },
+  "medical_distribution": {
+    "desc": "Medical Distribution Stocks",
+    "id": "f24eac61-a63a-4061-9973-30aef1897154",
+    "title": "Medical Distribution"
+  },
+  "medical_instruments_supplies": {
+    "desc": "Medical Instruments & Supplies Stocks",
+    "id": "5dcc2018-5313-4a27-b9a9-45ee0dcdda72",
+    "title": "Medical Instruments & Supplies"
+  },
+  "mega_cap_hc": {
+    "desc": "Stocks with Mega Cap in healthcare industry",
+    "id": "86889bb3-e9d9-464d-956a-4abe5a9728db",
+    "title": "Mega Cap Healthcare"
+  },
+  "metal_fabrication": {
+    "desc": "Metal Fabrication Stocks",
+    "id": "05acca9e-1aee-44b6-8224-c92459eb2ed8",
+    "title": "Metal Fabrication"
+  },
+  "morningstar_five_star_stocks": {
+    "desc": "A 5-star rating indicates that the stock is trading meaningfully below fair value with an exciting discount.",
+    "id": "c8235580-5fb0-47ae-9f5c-e70f2a0cbe5d",
+    "title": "Morningstar 5-Star Stocks"
+  },
+  "mortgage_finance": {
+    "desc": "Mortgage Finance Stocks",
+    "id": "fe8052af-d7ed-41bf-933d-dd0b4239e869",
+    "title": "Mortgage Finance"
+  },
+  "most_actives": {
+    "desc": "Discover the most traded equities in the trading day.",
+    "id": "437465ef-980e-4d8c-a860-de7cbfbab373",
+    "title": "Most Actives"
+  },
+  "most_actives_americas": {
+    "desc": "Stocks ordered in descending order by intraday trade volume",
+    "id": "a143f34f-7d90-473b-855b-67787326ce2c",
+    "title": "Most Actives Americas"
+  },
+  "most_actives_asia": {
+    "desc": "Discover the most traded equities in the trading day.",
+    "id": "2e23187d-c4ff-48a5-b498-161a80b0145b",
+    "title": "Most Actives"
+  },
+  "most_actives_au": {
+    "desc": "Stocks ordered in descending order by intraday trade volume for Australia",
+    "id": "d0dad29a-9a50-445b-8ca4-1367e51826eb",
+    "title": "Most Actives - Australia"
+  },
+  "most_actives_br": {
+    "desc": "Stocks ordered in descending order by intraday trade volume for Brazil",
+    "id": "ec23a32d-e108-465f-9d4b-e5db1d934f2e",
+    "title": "Most Actives - Brazil"
+  },
+  "most_actives_ca": {
+    "desc": "Stocks ordered in descending order by intraday trade volume for Canada",
+    "id": "5026cc58-c878-4f43-af38-efbffadce77f",
+    "title": "Most Actives - Canada"
+  },
+  "most_actives_cn": {
+    "desc": "Stocks ordered in descending order by intraday trade volume",
+    "id": "b22d26a2-754c-4723-aefc-de09eca12462",
+    "title": "Most Actives - CN"
+  },
+  "most_actives_cryptocurrencies": {
+    "desc": "Discover the most traded cryptocurrencies in the last 24 hours.",
+    "id": "28d9ee6a-e0e2-4e19-be0f-cda4b7ae384c",
+    "title": "Most Actives"
+  },
+  "most_actives_de": {
+    "desc": "Stocks ordered in descending order by intraday trade volume for Germany",
+    "id": "5b4148d2-5a6d-4466-b663-b5895f5bc583",
+    "title": "Most Actives - Germany"
+  },
+  "most_actives_dji": {
+    "desc": "Stocks ordered in descending order by intraday trade volume",
+    "id": "a423c5d4-9eff-4fb5-9995-93d06480ea91",
+    "title": "Most Actives - Dow Jones Industrial Average"
+  },
+  "most_actives_es": {
+    "desc": "Stocks ordered in descending order by intraday trade volume for Spain",
+    "id": "8d1545dc-2fd9-4cac-854e-88f74c54b5dc",
+    "title": "Most Actives - Spain"
+  },
+  "most_actives_etfs": {
+    "desc": "Discover the most traded ETFs in the trading day.",
+    "id": "76320b05-b87f-4d78-a8d7-11868c28cb44",
+    "title": "Most Actives"
+  },
+  "most_actives_etfs_asia": {
+    "desc": "Discover the most traded ETFs in the trading day.",
+    "id": "6add3eb0-1494-4756-abe5-6e30c6649293",
+    "title": "Most Actives"
+  },
+  "most_actives_etfs_europe": {
+    "desc": "Discover the most traded ETFs in the trading day.",
+    "id": "cd21364c-397a-4d79-ba4c-4fc801614242",
+    "title": "Most Actives"
+  },
+  "most_actives_europe": {
+    "desc": "Discover the most traded equities in the trading day.",
+    "id": "c46c7edd-c97f-4929-9ade-77ec21b86c18",
+    "title": "Most Actives"
+  },
+  "most_actives_fr": {
+    "desc": "Stocks ordered in descending order by intraday trade volume for France",
+    "id": "05f97149-f902-4cd3-8f72-f7768ac673e0",
+    "title": "Most Actives - France"
+  },
+  "most_actives_gb": {
+    "desc": "Stocks ordered in descending order by intraday trade volume for United Kingdom",
+    "id": "433c5af8-f58f-4d92-8338-7d928f558a0d",
+    "title": "Most Actives - United Kingdom"
+  },
+  "most_actives_hk": {
+    "desc": "Stocks ordered in descending order by intraday trade volume for Hong Kong",
+    "id": "9dbdb8ef-d0c2-446f-baab-be6997a20be8",
+    "title": "Most Actives - Hong Kong"
+  },
+  "most_actives_in": {
+    "desc": "Stocks ordered in descending order by intraday trade volume for India",
+    "id": "09a035cc-f535-4249-bfae-ed95e7a9e12e",
+    "title": "Most Actives - India"
+  },
+  "most_actives_it": {
+    "desc": "Stocks ordered in descending order by intraday trade volume for Italy",
+    "id": "2ec96414-6fb7-4da4-8600-cf6f82d0e6d8",
+    "title": "Most Actives - Italy"
+  },
+  "most_actives_ndx": {
+    "desc": "Stocks ordered in descending order by intraday trade volume",
+    "id": "393c6a0f-d975-45a7-91b5-478fd3847b31",
+    "title": "Most Actives - NASDAQ 100"
+  },
+  "most_actives_nz": {
+    "desc": "Stocks ordered in descending order by intraday trade volume for New Zealand",
+    "id": "b6b57880-3ce5-4f10-943b-a5b6dbf77f4d",
+    "title": "Most Actives - New Zealand"
+  },
+  "most_actives_options": {
+    "desc": "Discover the most traded options in the trading day.",
+    "id": "924cd8e4-e16e-49b1-a7ea-6a1a471fa3f5",
+    "title": "Most Actives"
+  },
+  "most_actives_sg": {
+    "desc": "Stocks ordered in descending order by intraday trade volume for Singapore",
+    "id": "96384b8f-b161-4eef-abf8-d1ce290da125",
+    "title": "Most Actives - Singapore"
+  },
+  "most_institutionally_bought_large_cap_stocks": {
+    "desc": "Large cap stocks with the highest institutional buying as a percentage of its outstanding shares.",
+    "id": "18feeba8-323c-4905-9300-b6f72af3e497",
+    "title": "Most Institutionally Bought Large Cap Stocks"
+  },
+  "most_institutionally_held_large_cap_stocks": {
+    "desc": "Large cap stocks with the highest institutional ownership as a percentage of its outstanding shares.",
+    "id": "d9bf8961-0dab-4e7a-89d2-91bbcff87da6",
+    "title": "Most Institutionally Held Large Cap Stocks"
+  },
+  "most_institutionally_sold_large_cap_stocks": {
+    "desc": "Large cap stocks with the highest institutional selling as a percentage of its outstanding shares.",
+    "id": "ef8cb87e-0d8c-46ad-8512-59113286ea50",
+    "title": "Most Institutionally Sold Large Cap Stocks"
+  },
+  "most_shorted_stocks": {
+    "desc": "Stocks with the highest short interest positions from Nasdaq and NYSE reports released every two weeks.",
+    "id": "679b1d2b-95d6-4731-9fd1-f9539ede458c",
+    "title": "Most Shorted Stocks"
+  },
+  "most_visited": {
+    "desc": "Stocks ordered in descending order by weekly page view growth",
+    "id": "9bff655f-1d5c-47b8-b662-1c9d052a1df0",
+    "title": "Most Visited Companies"
+  },
+  "most_visited_basic_materials": {
+    "desc": "Stocks in the Basic Materials sector ordered in descending order by weekly page view growth",
+    "id": "89ffe95d-8d19-4628-bbf6-092fa8cf4453",
+    "title": "Most Visited Basic Materials Companies"
+  },
+  "most_visited_communication_services": {
+    "desc": "Stocks in the Communication Services sector ordered in descending order by weekly page view growth",
+    "id": "720f5d28-44d7-4c0b-9cb5-4c4d4b117845",
+    "title": "Most Visited Communication Services Companies"
+  },
+  "most_visited_consumer_cyclical": {
+    "desc": "Stocks in the Consumer Cyclical sector ordered in descending order by weekly page view growth",
+    "id": "78fb9235-9d53-4fd6-a924-952593e75243",
+    "title": "Most Visited Consumer Cyclical Companies"
+  },
+  "most_visited_consumer_defensive": {
+    "desc": "Stocks in the Consumer Defensive sector ordered in descending order by weekly page view growth",
+    "id": "5c09c497-4f26-4055-98dc-97e25709db6e",
+    "title": "Most Visited Consumer Defensive Companies"
+  },
+  "most_visited_energy": {
+    "desc": "Stocks in the Energy sector ordered in descending order by weekly page view growth",
+    "id": "aa7dd02f-3495-4a6d-a0be-2eb42b231f94",
+    "title": "Most Visited Energy Companies"
+  },
+  "most_visited_financial_services": {
+    "desc": "Stocks in the Financial Services sector ordered in descending order by weekly page view growth",
+    "id": "c207c8b1-796b-4a39-a4a0-5f7d8b341b09",
+    "title": "Most Visited Financial Services Companies"
+  },
+  "most_visited_healthcare": {
+    "desc": "Stocks in the Healthcare sector ordered in descending order by weekly page view growth",
+    "id": "c66c4173-2f75-49eb-b9a1-659a535a48dc",
+    "title": "Most Visited Healthcare Companies"
+  },
+  "most_visited_industrials": {
+    "desc": "Stocks in the Industrials sector ordered in descending order by weekly page view growth",
+    "id": "2fd2ac4a-f6b7-45bc-910a-b5c9965ddc72",
+    "title": "Most Visited Industrials Companies"
+  },
+  "most_visited_real_estate": {
+    "desc": "Stocks in the Real Estate sector ordered in descending order by weekly page view growth",
+    "id": "e79defb1-9fad-4033-8a89-f4c58da39629",
+    "title": "Most Visited Real Estate Companies"
+  },
+  "most_visited_technology": {
+    "desc": "Stocks in the Technology sector ordered in descending order by weekly page view growth",
+    "id": "d52b84f8-818a-427a-880a-4df2d6112e9a",
+    "title": "Most Visited Technology Companies"
+  },
+  "most_visited_utilities": {
+    "desc": "Stocks in the Utilities sector ordered in descending order by weekly page view growth",
+    "id": "038d9521-ad03-4ba2-8061-30a49493059c",
+    "title": "Most Visited Utilities Companies"
+  },
+  "most_watched_tickers": {
+    "desc": "Top 30 tickers with highest portfolioheldcount",
+    "id": "04c9d12e-f0a3-4ab8-bab8-904a2d1c3ab2",
+    "title": "Most added to watchlist"
+  },
+  "ms_basic_materials": {
+    "desc": "Basic Materials ordered by intra day market cap for US region",
+    "id": "a4f8a58b-e458-44fe-b304-04af382a364e",
+    "title": "Basic Materials Sector"
+  },
+  "ms_communication_services": {
+    "desc": "Communication Services ordered by intra day market cap for US region",
+    "id": "b8a44a72-2d49-4a2f-9261-f0fff3c2e4e2",
+    "title": "Communication Services Sector"
+  },
+  "ms_consumer_cyclical": {
+    "desc": "Consumer Cyclical ordered by intra day market cap for US region",
+    "id": "4969e5a1-b0e0-416e-9ae3-191414339e3a",
+    "title": "Consumer Cyclical Sector"
+  },
+  "ms_consumer_defensive": {
+    "desc": "Consumer Defensive ordered by intra day market cap for US region",
+    "id": "6a15b340-2e3c-44a6-b339-b7ae5c097be5",
+    "title": "Consumer Defensive Sector"
+  },
+  "ms_energy": {
+    "desc": "Energy Services ordered by intra day market cap for US region",
+    "id": "2efb4ff8-64f4-4941-abb5-a399a6d0f66a",
+    "title": "Energy Services Sector"
+  },
+  "ms_financial_services": {
+    "desc": "Financial Services ordered by intra day market cap for US region",
+    "id": "667f5248-3710-40d9-8d95-6582fdfa254c",
+    "title": "Financial Services Sector"
+  },
+  "ms_healthcare": {
+    "desc": "Healthcare ordered by intra day market cap for US region",
+    "id": "e568d534-af60-4d20-a192-93bd4508f1bf",
+    "title": "Healthcare Sector"
+  },
+  "ms_industrials": {
+    "desc": "Industrials Services ordered by intra day market cap for US region",
+    "id": "caf102b6-2c28-4abc-9d81-b13d710af432",
+    "title": "Industrials Services Sector"
+  },
+  "ms_real_estate": {
+    "desc": "Real Estate ordered by intra day market cap for US region",
+    "id": "69d56754-89fd-4bc4-9f57-66ed42291311",
+    "title": "Real Estate Sector"
+  },
+  "ms_technology": {
+    "desc": "Technology Services ordered by intra day market cap for US region",
+    "id": "c7b3f121-188a-4846-83e4-f049fab045cd",
+    "title": "Technology Services Sector"
+  },
+  "ms_utilities": {
+    "desc": "Utilities ordered by intra day market cap for US region",
+    "id": "590cedc7-6ddc-40dc-9839-68b0c1572274",
+    "title": "Utilities Sector"
+  },
+  "net_net_strategy": {
+    "desc": "As popularized by Graham, discover equities that trade below their liquidation value based on the NNWC metric.",
+    "id": "f3afc5dd-cbc3-4c7b-82ae-2835963be5ec",
+    "title": "Net-Net Strategy"
+  },
+  "net_net_strategy_asia": {
+    "desc": "As popularized by Graham, discover equities that trade below their liquidation value based on the NNWC metric.",
+    "id": "73791934-528b-44e3-808b-4cd1a24424ac",
+    "title": "Net-Net Strategy"
+  },
+  "net_net_strategy_europe": {
+    "desc": "As popularized by Graham, discover equities that trade below their liquidation value based on the NNWC metric.",
+    "id": "bf211886-2e58-49ca-9d32-ff1f8fa6293b",
+    "title": "Net-Net Strategy"
+  },
+  "oil_gas_drilling": {
+    "desc": "Oil & Gas Drilling Stocks",
+    "id": "75c335ad-77c8-4368-9932-bfb462c3dc06",
+    "title": "Oil & Gas Drilling"
+  },
+  "oil_gas_e_p": {
+    "desc": "Oil & Gas E&P Stocks",
+    "id": "40cd525d-2b36-40c4-bc95-33b133422ab0",
+    "title": "Oil & Gas E&P"
+  },
+  "oil_gas_equipment_services": {
+    "desc": "Oil & Gas Equipment & Services Stocks",
+    "id": "051612b8-dbf2-44ac-9ee8-d0a0e105b199",
+    "title": "Oil & Gas Equipment & Services"
+  },
+  "oil_gas_integrated": {
+    "desc": "Oil & Gas Integrated Stocks",
+    "id": "f4804676-79ae-4d01-8e45-6f52f85998c9",
+    "title": "Oil & Gas Integrated"
+  },
+  "oil_gas_midstream": {
+    "desc": "Oil & Gas Midstream Stocks",
+    "id": "00374e32-6fb7-44c4-b828-1ba7b3080cf2",
+    "title": "Oil & Gas Midstream"
+  },
+  "oil_gas_refining_marketing": {
+    "desc": "Oil & Gas Refining & Marketing Stocks",
+    "id": "59bef9a7-5bb4-4e67-8b22-513227cc55d6",
+    "title": "Oil & Gas Refining & Marketing"
+  },
+  "other_industrial_metals_mining": {
+    "desc": "Other Industrial Metals & Mining Stocks",
+    "id": "2e1dd2f6-189b-4fb0-857d-79aec8ecef15",
+    "title": "Other Industrial Metals & Mining"
+  },
+  "other_precious_metals_mining": {
+    "desc": "Other Precious Metals & Mining Stocks",
+    "id": "62e97ea1-46c8-4e6e-86f2-901a4ffa8b47",
+    "title": "Other Precious Metals & Mining"
+  },
+  "packaged_foods": {
+    "desc": "Packaged Foods Stocks",
+    "id": "208c5e2a-b05c-40bc-8d92-6a0e97570556",
+    "title": "Packaged Foods"
+  },
+  "packaging_containers": {
+    "desc": "Packaging & Containers Stocks",
+    "id": "70c912eb-3cfb-4dab-ae94-4f81d0910ea6",
+    "title": "Packaging & Containers"
+  },
+  "paper_paper_products": {
+    "desc": "Paper & Paper Products Stocks",
+    "id": "f75ad8b4-22c7-4aba-b93b-1f543191f5bf",
+    "title": "Paper & Paper Products"
+  },
+  "personal_services": {
+    "desc": "Personal Services Stocks",
+    "id": "7d89c0ef-3d77-47e0-9d30-b723ee9d824b",
+    "title": "Personal Services"
+  },
+  "pharmaceutical_retailers": {
+    "desc": "Pharmaceutical Retailers Stocks",
+    "id": "293a91a7-b9e5-4b39-9792-4624bc78b99e",
+    "title": "Pharmaceutical Retailers"
+  },
+  "pollution_treatment_controls": {
+    "desc": "Pollution & Treatment Controls Stocks",
+    "id": "5bd0d463-53ed-4ad4-bcd4-de0efa8460d3",
+    "title": "Pollution & Treatment Controls"
+  },
+  "portfolio_actions_most_added": {
+    "desc": "Portfolio Actions Most Added",
+    "id": "288f1df3-0be8-4ecf-8131-03337550b7ed",
+    "title": "Portfolio Actions Most Added"
+  },
+  "portfolio_actions_most_deleted": {
+    "desc": "Portfolio Actions Most Deleted",
+    "id": "ae8ea26f-ad24-4183-9e24-a40c6c440179",
+    "title": "Portfolio Actions Most Deleted"
+  },
+  "portfolio_anchors": {
+    "desc": "Funds with Performance Rating of 4 & 5 and top-half returns that could serve as a rock-solid core of an investor's portfolio.",
+    "id": "7a0584d9-28a1-4a94-ac68-21f0aab91c4a",
+    "title": "Portfolio Anchors"
+  },
+  "precious_metal_etfs": {
+    "desc": "Discover equity precious metal-focused ETFs.",
+    "id": "63e7f272-cd8d-4307-9002-eb98746a036a",
+    "title": "Precious Metal ETFs"
+  },
+  "precious_metal_mutual_funds": {
+    "desc": "Discover equity precious metal-focused mutual funds.",
+    "id": "2b0f0d69-53ad-4a85-bcd6-8b6c1035bd33",
+    "title": "Precious Metal Mutual Funds"
+  },
+  "publishing": {
+    "desc": "Publishing Stocks",
+    "id": "9061cba6-4150-47e0-ba32-bc59f824a6da",
+    "title": "Publishing"
+  },
+  "railroads": {
+    "desc": "Railroads Stocks",
+    "id": "493c9c2f-8e7c-4e10-8287-608567b59d56",
+    "title": "Railroads"
+  },
+  "real_estate_development": {
+    "desc": "Real Estate—Development Stocks",
+    "id": "a5bdd975-cf17-4f89-86a8-f85ca99bb8de",
+    "title": "Real Estate—Development"
+  },
+  "real_estate_diversified": {
+    "desc": "Real Estate—Diversified Stocks",
+    "id": "95de06d7-7c2b-46fb-8ef8-72485007f1f0",
+    "title": "Real Estate—Diversified"
+  },
+  "real_estate_services": {
+    "desc": "Real Estate Services Stocks",
+    "id": "61a2d1b7-443a-4b5a-9792-c9584cecd6f1",
+    "title": "Real Estate Services"
+  },
+  "recreational_vehicles": {
+    "desc": "Recreational Vehicles Stocks",
+    "id": "d6f2cf97-b467-4709-a4e9-d351e66628d8",
+    "title": "Recreational Vehicles"
+  },
+  "reit_diversified": {
+    "desc": "REIT—Diversified Stocks",
+    "id": "8b05f1c0-8250-455b-a69f-daaa92c30bba",
+    "title": "REIT—Diversified"
+  },
+  "reit_healthcare_facilities": {
+    "desc": "REIT—Healthcare Facilities Stocks",
+    "id": "5875b16e-cf4e-47dd-ac92-2d0e9ecfd608",
+    "title": "REIT—Healthcare Facilities"
+  },
+  "reit_hotel_motel": {
+    "desc": "REIT—Hotel & Motel Stocks",
+    "id": "e35bd5d6-6184-4fae-a5ef-6eabd3b2a5c8",
+    "title": "REIT—Hotel & Motel"
+  },
+  "reit_industrial": {
+    "desc": "REIT—Industrial Stocks",
+    "id": "1f0611ca-ea24-4a25-af9a-c32ee7fc0b4a",
+    "title": "REIT—Industrial"
+  },
+  "reit_mortgage": {
+    "desc": "REIT—Mortgage Stocks",
+    "id": "78956309-a5ef-4d4f-88d9-6555940cb525",
+    "title": "REIT—Mortgage"
+  },
+  "reit_office": {
+    "desc": "REIT—Office Stocks",
+    "id": "9f1e2240-2cc4-4a96-8795-86867133c959",
+    "title": "REIT—Office"
+  },
+  "reit_residential": {
+    "desc": "REIT—Residential Stocks",
+    "id": "8e9e7ec7-3248-4d8e-96f5-aeb6c42ac77b",
+    "title": "REIT—Residential"
+  },
+  "reit_retail": {
+    "desc": "REIT—Retail Stocks",
+    "id": "0ecb1fc8-2c80-43b6-98f0-fe1fb1c2b176",
+    "title": "REIT—Retail"
+  },
+  "reit_specialty": {
+    "desc": "REIT—Specialty Stocks",
+    "id": "1d63bc0a-1f95-4a78-8f86-ab359a4776ab",
+    "title": "REIT—Specialty"
+  },
+  "rental_leasing_services": {
+    "desc": "Rental & Leasing Services Stocks",
+    "id": "d4711c7a-0c1f-4cb3-8743-b6c72065502a",
+    "title": "Rental & Leasing Services"
+  },
+  "residential_construction": {
+    "desc": "Residential Construction Stocks",
+    "id": "56c1ea81-2d1b-4318-9d34-1a8630b52708",
+    "title": "Residential Construction"
+  },
+  "resorts_casinos": {
+    "desc": "Resorts & Casinos Stocks",
+    "id": "4da54a7f-66d2-42bd-a9cd-545289082a8d",
+    "title": "Resorts & Casinos"
+  },
+  "restaurants": {
+    "desc": "Restaurants Stocks",
+    "id": "8376c341-3bc4-46bc-8549-45df4724d16a",
+    "title": "Restaurants"
+  },
+  "scientific_technical_instruments": {
+    "desc": "Scientific & Technical Instruments Stocks",
+    "id": "24c50979-bb02-43db-8f35-548d0c5446c9",
+    "title": "Scientific & Technical Instruments"
+  },
+  "security_protection_services": {
+    "desc": "Security & Protection Services Stocks",
+    "id": "7b9d1a1c-1fc6-4883-8844-bd39034da6a4",
+    "title": "Security & Protection Services"
+  },
+  "semiconductor_equipment_materials": {
+    "desc": "Semiconductor Equipment & Materials Stocks",
+    "id": "2b69f4cf-4815-4963-979a-e20464936232",
+    "title": "Semiconductor Equipment & Materials"
+  },
+  "semiconductors": {
+    "desc": "Semiconductors Stocks",
+    "id": "1aae01f4-bcbc-4a96-a1de-b5569f113699",
+    "title": "Semiconductors"
+  },
+  "shell_companies": {
+    "desc": "Shell Companies Stocks",
+    "id": "7f37f816-a79c-4145-ba45-9f119f07ce7d",
+    "title": "Shell Companies"
+  },
+  "silver": {
+    "desc": "Silver Stocks",
+    "id": "fd2e2676-b2a8-4c45-ac10-e76a9be49151",
+    "title": "Silver"
+  },
+  "small_cap_gainers": {
+    "desc": "Small cap stocks with percentchange greater than 5%",
+    "id": "483129f4-b25a-44c1-afca-8934593f3f6d",
+    "title": "Small caps with momentum"
+  },
+  "software_application": {
+    "desc": "Software—Application Stocks",
+    "id": "e322e6ad-aedb-4330-965a-b6a949c5c45c",
+    "title": "Software—Application"
+  },
+  "software_infrastructure": {
+    "desc": "Software—Infrastructure Stocks",
+    "id": "4e763ffb-03ba-4ff9-b515-35a1665faa45",
+    "title": "Software—Infrastructure"
+  },
+  "solar": {
+    "desc": "Solar Stocks",
+    "id": "9f9e3c35-6a54-4292-aeb1-dce476941244",
+    "title": "Solar"
+  },
+  "solid_large_growth_funds": {
+    "desc": "Large Growth Funds with Performance Rating of 4 & 5 and top-half returns",
+    "id": "5704ade5-098b-4c5e-997f-e50b32be7a55",
+    "title": "Solid Large Growth Funds"
+  },
+  "solid_midcap_growth_funds": {
+    "desc": "Mid-Cap Growth Funds with Performance Rating of 4 & 5 and top-half returns",
+    "id": "d7235ede-59ce-40ad-99f9-5c7e4ec2c5e6",
+    "title": "Solid Mid-Cap Growth Funds"
+  },
+  "sp_500_etfs": {
+    "desc": "Uncover ETFs advertised as being related to the S&P 500.",
+    "id": "e25ca1d3-f3c7-45ca-8566-13ae3f4d139e",
+    "title": "S&P 500 ETFs"
+  },
+  "sp_500_etfs_asia": {
+    "desc": "Uncover ETFs advertised as being related to the S&P 500.",
+    "id": "8da58869-0ab4-4085-a3cd-cf70d50c2078",
+    "title": "S&P 500 ETFs"
+  },
+  "sp_500_etfs_europe": {
+    "desc": "Uncover ETFs advertised as being related to the S&P 500.",
+    "id": "aa061fa7-9503-41b8-95f8-e9fdf86f7eb7",
+    "title": "S&P 500 ETFs"
+  },
+  "specialty_business_services": {
+    "desc": "Specialty Business Services Stocks",
+    "id": "2978b66d-7cda-4fed-a28f-ea10c78ac500",
+    "title": "Specialty Business Services"
+  },
+  "specialty_chemicals": {
+    "desc": "Specialty Chemicals Stocks",
+    "id": "a2271fd1-aa0f-4840-a7bb-783e92b3b515",
+    "title": "Specialty Chemicals"
+  },
+  "specialty_industrial_machinery": {
+    "desc": "Specialty Industrial Machinery Stocks",
+    "id": "18ec4d96-9af4-409e-8448-98f86e4263c5",
+    "title": "Specialty Industrial Machinery"
+  },
+  "specialty_retail": {
+    "desc": "Specialty Retail Stocks",
+    "id": "5cbc47de-7de8-4c60-853f-110018f5e3bd",
+    "title": "Specialty Retail"
+  },
+  "staffing_employment_services": {
+    "desc": "Staffing & Employment Services Stocks",
+    "id": "69a6c527-bb1e-4863-9352-0c86c31c4bd2",
+    "title": "Staffing & Employment Services"
+  },
+  "steel": {
+    "desc": "Steel Stocks",
+    "id": "a5c6e330-eea5-4e2b-b196-ca2066f7141c",
+    "title": "Steel"
+  },
+  "stocks_most_bought_by_hedge_funds": {
+    "desc": "Stocks most bought by Hedge Funds as a percentage of outstanding shares.",
+    "id": "57b71b5c-1c87-4a1d-9ceb-b3c86bee7daf",
+    "title": "Stocks Most Bought by Hedge Funds"
+  },
+  "stocks_most_bought_by_pension_fund": {
+    "desc": "Stocks most bought by Pension Fund as a percentage of outstanding shares.",
+    "id": "5c7ed9e4-46f8-4007-99c3-6ebae5712c7c",
+    "title": "Stocks Most Bought by Pension Fund"
+  },
+  "stocks_most_bought_by_private_equity": {
+    "desc": "Stocks most bought by Private Equity as a percentage of outstanding shares.",
+    "id": "a62cd3c8-b414-4da0-a75d-ea4911dd9061",
+    "title": "Stocks Most Bought by Private Equity"
+  },
+  "stocks_most_bought_by_sovereign_wealth_fund": {
+    "desc": "Stocks most bought by Sovereign Wealth Fund as a percentage of outstanding shares.",
+    "id": "b47910ce-cf2a-4113-8775-d27d0881addd",
+    "title": "Stocks Most Bought by Sovereign Wealth Fund"
+  },
+  "stocks_with_most_institutional_buyers": {
+    "desc": "Stocks with the highest number of institutional buyers.",
+    "id": "0ed4f63c-2b43-45ee-b7a2-721ca11bf349",
+    "title": "Stocks with Most Institutional Buyers"
+  },
+  "stocks_with_most_institutional_sellers": {
+    "desc": "Stocks with the highest number of institutional sellers.",
+    "id": "b54dacf5-3844-4e6e-827d-b3e3bf1ec89d",
+    "title": "Stocks with Most Institutional Sellers"
+  },
+  "strong_undervalued_stocks": {
+    "desc": "Undervalued stocks with a robust and consistent history of earnings and revenue growth.",
+    "id": "e2276d18-9203-4b75-8efd-0f3b5f5cde94",
+    "title": "Strong Undervalued Stocks"
+  },
+  "technology_etfs": {
+    "desc": "Discover technology-focused ETFs.",
+    "id": "dee4c568-74ae-4284-bf4e-7525b1eabf02",
+    "title": "Technology ETFs"
+  },
+  "technology_mutual_funds": {
+    "desc": "Discover technology-focused mutual funds.",
+    "id": "6666a1fc-9b01-4398-be32-412141e76439",
+    "title": "Technology Mutual Funds"
+  },
+  "telecom_services": {
+    "desc": "Telecom Services Stocks",
+    "id": "a9928231-7c89-469b-ac0f-1ae93e79c657",
+    "title": "Telecom Services"
+  },
+  "textile_manufacturing": {
+    "desc": "Textile Manufacturing Stocks",
+    "id": "19847b80-4e4f-4398-936d-de43161eda6f",
+    "title": "Textile Manufacturing"
+  },
+  "the_acquirers_multiple": {
+    "desc": "Uncover undervalued equities by comparing the enterprise value to its earnings before interest and taxes.",
+    "id": "01bc42f4-514d-499c-a015-1e1a3f171d2c",
+    "title": "The Acquirer's Multiple"
+  },
+  "the_acquirers_multiple_asia": {
+    "desc": "Uncover undervalued equities by comparing the total cost to the operating income of the company.",
+    "id": "25f03e5a-6659-49e0-98fb-41456e713e56",
+    "title": "The Acquirer's Multiple"
+  },
+  "the_acquirers_multiple_europe": {
+    "desc": "Uncover undervalued equities by comparing the total cost to the operating income of the company.",
+    "id": "4cfbf7d1-38d4-4f64-b9a3-ea13921b1769",
+    "title": "The Acquirer's Multiple"
+  },
+  "thermal_coal": {
+    "desc": "Thermal Coal Stocks",
+    "id": "78e69f52-be0b-4346-9dcf-27d778fbe047",
+    "title": "Thermal Coal"
+  },
+  "tobacco": {
+    "desc": "Tobacco Stocks",
+    "id": "ca5ff11e-c43f-4a54-a409-fea6d29766e7",
+    "title": "Tobacco"
+  },
+  "tools_accessories": {
+    "desc": "Tools & Accessories Stocks",
+    "id": "9e622c85-3b94-41aa-8c76-8b488c2d27ce",
+    "title": "Tools & Accessories"
+  },
+  "top_energy_us": {
+    "desc": "Energy ordered by Percent Change for US region",
+    "id": "9019aa39-cffd-4ffb-8c6c-dc6e9c48ef11",
+    "title": "Top Energy US"
+  },
+  "top_etfs": {
+    "desc": "ETFs with Performance Rating of 4 & 5 ordered by Percent Change",
+    "id": "9976e04d-d1cb-49d4-abab-f8b45e0ae91c",
+    "title": "Top ETFs"
+  },
+  "top_etfs_hk": {
+    "desc": "ETFs ordered by Percent Change for HK region",
+    "id": "131fc0f0-3c7b-476d-99e3-115a91680adf",
+    "title": "Top ETFs HK"
+  },
+  "top_etfs_in": {
+    "desc": "ETFs ordered by Percent Change for IN region",
+    "id": "658effc7-8feb-4c65-9721-451e941be158",
+    "title": "Top ETFs IN"
+  },
+  "top_etfs_us": {
+    "desc": "ETFs ordered by Percent Change for US region",
+    "id": "b34d612c-4204-4fd5-b0c4-2fca8b596411",
+    "title": "Top ETFs US"
+  },
+  "top_mutual_funds": {
+    "desc": "Funds with Performance Rating of 4 & 5 ordered by Percent Change",
+    "id": "2ca6caed-e715-4fec-986a-fe68599160d9",
+    "title": "Top Mutual Funds"
+  },
+  "top_mutual_funds_au": {
+    "desc": "Funds with Performance Rating of 4 & 5 ordered by Percent Change for AU region",
+    "id": "ae9de583-95cc-4269-821f-31a6a19febae",
+    "title": "Top Mutual funds AU"
+  },
+  "top_mutual_funds_br": {
+    "desc": "Funds with Performance Rating of 4 & 5 ordered by Percent Change for BR region",
+    "id": "89d702fb-8a14-4f54-8ded-86da666a8d0b",
+    "title": "Top Mutual funds BR"
+  },
+  "top_mutual_funds_ca": {
+    "desc": "Mutual Funds ordered by Percent Change for CA region",
+    "id": "71f592c6-6dce-4508-953a-311bfe76d0bc",
+    "title": "Top Mutual Funds CA"
+  },
+  "top_mutual_funds_de": {
+    "desc": "Funds with Performance Rating of 4 & 5 ordered by Percent Change for DE region",
+    "id": "21c3ea5b-9d0d-47ef-b12c-efa620c28c7f",
+    "title": "Top Mutual funds DE"
+  },
+  "top_mutual_funds_es": {
+    "desc": "Mutual Funds ordered by Percent Change for ES region",
+    "id": "3cb76596-ccf6-4bdf-9d37-93ac03515334",
+    "title": "Top Mutual funds ES"
+  },
+  "top_mutual_funds_fr": {
+    "desc": "MutualFunds ordered by Percent Change for FR region",
+    "id": "a58a9112-738c-4c59-afc2-b5f94ea923a8",
+    "title": "Top Mutual Funds FR"
+  },
+  "top_mutual_funds_gb": {
+    "desc": "Funds with Performance Rating of 4 & 5 ordered by Percent Change for GB region",
+    "id": "8214a99f-4992-4e6a-9eab-1b68ba8124cf",
+    "title": "Top Mutual funds GB"
+  },
+  "top_mutual_funds_hk": {
+    "desc": "MutualFunds ordered by Percent Change for HK region",
+    "id": "b6e7a9e9-56d5-499b-b4af-018f45a65cd5",
+    "title": "Top Mutual Funds HK"
+  },
+  "top_mutual_funds_in": {
+    "desc": "Top Mutual funds for India",
+    "id": "1d7eb3bf-ba14-4eae-b09c-b72c772bd995",
+    "title": "Top Mutual funds for India"
+  },
+  "top_mutual_funds_it": {
+    "desc": "MutualFunds ordered by Percent Change for IT region",
+    "id": "dc43d757-d6c1-4129-bcf4-64e2fdd56472",
+    "title": "Top Mutual Funds IT"
+  },
+  "top_mutual_funds_nz": {
+    "desc": "Funds with Performance Rating of 4 & 5 ordered by Percent Change for NZ region",
+    "id": "5a740873-637d-4895-bd5e-038a0d189025",
+    "title": "Top Mutual funds NZ"
+  },
+  "top_mutual_funds_sg": {
+    "desc": "Funds with Performance Rating of 4 & 5 ordered by Percent Change for SG region",
+    "id": "c36f090e-98c0-40de-8cca-060e4d123304",
+    "title": "Top Mutual funds SG"
+  },
+  "top_mutual_funds_us": {
+    "desc": "Funds with Performance Rating of 4 & 5 ordered by Percent Change for US region",
+    "id": "b749fa8b-a782-4e64-9224-1ad76e8f3d6c",
+    "title": "Top Mutual funds US"
+  },
+  "top_options_implied_volatality": {
+    "desc": "Discover the options with the highest implied volatility.",
+    "id": "671c40b0-5ea8-4063-89b9-9db45bf9edf0",
+    "title": "Highest Implied Volatility"
+  },
+  "top_options_open_interest": {
+    "desc": "Discover the options with the highest open interest.",
+    "id": "65f51cea-8dc8-4e56-9f99-6ef7720eb69c",
+    "title": "Highest Open Interest"
+  },
+  "top_performing_etfs": {
+    "desc": "Uncover the ETFs with a Morningstar Performance Rating of 4 or 5.",
+    "id": "540ecf9c-5233-41d7-8adb-3daa5962ffe5",
+    "title": "Top Performing"
+  },
+  "top_performing_etfs_asia": {
+    "desc": "Uncover the ETFs with a Morningstar Performance Rating of 4 or 5.",
+    "id": "83cd34b7-7372-473e-97d7-1b9351203da7",
+    "title": "Top Performing"
+  },
+  "top_performing_etfs_europe": {
+    "desc": "Uncover the ETFs with a Morningstar Performance Rating of 4 or 5.",
+    "id": "416d6a69-a3e6-4de9-8cd2-b551b2bdafb3",
+    "title": "Top Performing"
+  },
+  "top_performing_mutual_funds": {
+    "desc": "Uncover the mutual funds with a Morningstar Performance Rating of 4 or 5.",
+    "id": "5ad812ec-0e30-4d5e-a37b-72c96ff8a6f5",
+    "title": "Top Performing"
+  },
+  "top_performing_mutual_funds_asia": {
+    "desc": "Uncover the mutual funds with a Morningstar Performance Rating of 4 or 5.",
+    "id": "cca0a3c4-caf1-4849-93b1-17db6dc7dc8a",
+    "title": "Top Performing"
+  },
+  "top_performing_mutual_funds_europe": {
+    "desc": "Uncover the mutual funds with a Morningstar Performance Rating of 4 or 5.",
+    "id": "0e910bbb-a6c4-4cb4-a4e5-d0a6881f0aee",
+    "title": "Top Performing"
+  },
+  "top_stocks_owned_by_cathie_wood": {
+    "desc": "Cathie Wood's top holdings as reported on her 13F filings.",
+    "id": "d70e5ae4-8714-4570-bfb5-2fe3915a51dc",
+    "title": "Top Stocks owned by Cathie Wood"
+  },
+  "top_stocks_owned_by_goldman_sachs": {
+    "desc": "Goldman Sachs's top holdings as reported on their 13F filings.",
+    "id": "26ff040e-7287-453c-b29b-3239530a71bd",
+    "title": "Top Stocks owned by Goldman Sachs"
+  },
+  "top_stocks_owned_by_ray_dalio": {
+    "desc": "Ray Dalio's top holdings as reported on his 13F filings.",
+    "id": "fe5923a9-47bc-44c3-a48b-394ed78b2384",
+    "title": "Top Stocks owned by Ray Dalio"
+  },
+  "top_stocks_owned_by_warren_buffet": {
+    "desc": "Warren Buffet's top holdings as reported on his 13F filings.",
+    "id": "a83d5ef1-9306-43ee-8123-c4503e9b51ac",
+    "title": "Top Stocks owned by Warren Buffet"
+  },
+  "travel_services": {
+    "desc": "Travel Services Stocks",
+    "id": "e9d2d268-7502-479e-a608-dfeefa90b027",
+    "title": "Travel Services"
+  },
+  "trucking": {
+    "desc": "Trucking Stocks",
+    "id": "44aab0f6-4878-45c3-885f-6c5c3d943c75",
+    "title": "Trucking"
+  },
+  "undervalued_growth_stocks": {
+    "desc": "Stocks with earnings growth rates better than 25% and relatively low PE and PEG ratios.",
+    "id": "b597175e-7243-4b42-82da-6811218a0945",
+    "title": "Undervalued Growth Stocks"
+  },
+  "undervalued_large_caps": {
+    "desc": "Large cap stocks that are potentially undervalued, ordered descending by volume",
+    "id": "e31b19b8-efe0-4ed1-8856-7715c2ef858d",
+    "title": "Potentially undervalued large cap stocks"
+  },
+  "undervalued_wide_moat_stocks": {
+    "desc": "Morningstar's undervalued stocks with a sustainable competitive advantage. A company with a wide economic moat can fend off competition for at least 20 years and earn high returns on capital for many years to come.",
+    "id": "0eaa1603-5d0a-427d-80f2-c69087dba4de",
+    "title": "Undervalued Wide-Moat Stocks"
+  },
+  "upside_breakout_stocks_daily": {
+    "desc": "Upside breakout stocks on a daily chart by Trading Central",
+    "id": "c8d23d60-84e3-4f32-8bca-fb2f04251390",
+    "title": "Upside Breakout Stocks"
+  },
+  "uranium": {
+    "desc": "Uranium Stocks",
+    "id": "c5467aa6-39ac-4ec3-bc0b-213e72ae9149",
+    "title": "Uranium"
+  },
+  "utilities_diversified": {
+    "desc": "Utilities—Diversified Stocks",
+    "id": "ba4e7e3d-d570-4d48-a85f-a81321233703",
+    "title": "Utilities—Diversified"
+  },
+  "utilities_independent_power_producers": {
+    "desc": "Utilities—Independent Power Producers Stocks",
+    "id": "ca979acd-b141-490a-b9e4-f5e03d23f7f9",
+    "title": "Utilities—Independent Power Producers"
+  },
+  "utilities_regulated_electric": {
+    "desc": "Utilities—Regulated Electric Stocks",
+    "id": "d15b8324-aa7d-421c-9da3-51a2e963bbda",
+    "title": "Utilities—Regulated Electric"
+  },
+  "utilities_regulated_gas": {
+    "desc": "Utilities—Regulated Gas Stocks",
+    "id": "7af3cba2-209a-4efd-968a-332e4e0bd0a3",
+    "title": "Utilities—Regulated Gas"
+  },
+  "utilities_regulated_water": {
+    "desc": "Utilities—Regulated Water Stocks",
+    "id": "74930302-d4d3-4425-933b-4ef26a41a446",
+    "title": "Utilities—Regulated Water"
+  },
+  "utilities_renewable": {
+    "desc": "Utilities—Renewable Stocks",
+    "id": "5fd7ee7b-4966-4db3-b427-d87b3cd0995a",
+    "title": "Utilities—Renewable"
+  },
+  "waste_management": {
+    "desc": "Waste Management Stocks",
+    "id": "76d69c29-2f57-4606-88f8-7fbbc2442430",
+    "title": "Waste Management"
+  }
 }


### PR DESCRIPTION
Closes #107 

- My guess is this screeners list updates quite a bit.
- Should eventually have a more robust way of getting available screeners.  This list is retrieved from this url - `https://query2.finance.yahoo.com/v1/finance/screener/predefined/list`.  The request takes 15-30 seconds to return a response so would most likely need to work off of cached data somewhere.  Out of scope for this particular PR.