### PR TITLE
Fix 163

### DIFF
--- a/yahooquery/utils/__init__.py
+++ b/yahooquery/utils/__init__.py
@@ -141,14 +141,14 @@ def _get_daily_index(data, index_utc, adj_timezone):
     times = index_local.time
 
     bv = times <= datetime.time(14)
-    if (bv).all():
-        index = index_local.floor("d")
+    if (bv).all() or data["meta"].get("exchangeName", "Nope") == "SAO":  # see issue 163
+        index = index_local.floor("d", ambiguous=True)
     elif (~bv).all():
-        index = index_local.ceil("d")
+        index = index_local.ceil("d", ambiguous=True)
     else:
         # mix of open times pre and post 14:00.
-        index1 = index_local[bv].floor("d")
-        index2 = index_local[~bv].ceil("d")
+        index1 = index_local[bv].floor("d", ambiguous=True)
+        index2 = index_local[~bv].ceil("d", ambiguous=True)
         index = index1.union(index2)
 
     index = pd.Index(index.date)


### PR DESCRIPTION
A couple of fixes for #163 as described there.

The bugs are for (relatively) edge cases that are still trickling in relating to changes made in #129.

Regarding "^BVSP", rather than being a problem with the `yahooquery` implementation per se, the bug's origins are in inconsistent indexing by Yahoo of instruments trading on the SAO exchange. The fix here is specific to those instruments.

For whatever reason the daily data for the following 10 sessions in 2021 are being indexed around the SAO exchange close time rather than, as is normal, on the exchange open time:
```python
DatetimeIndex(['2021-01-12 18:05:00-03:00', '2021-02-12 18:05:00-03:00',
               '2021-03-12 19:05:00-03:00', '2021-04-12 19:05:00-03:00',
               '2021-05-12 19:05:00-03:00', '2021-07-12 19:05:00-03:00',
               '2021-08-12 19:05:00-03:00', '2021-11-12 18:05:00-03:00',
               '2021-11-19 18:05:00-03:00', '2021-11-22 18:05:00-03:00'],
              dtype='datetime64[ns, America/Sao_Paulo]', freq=None)
```

I don't think it's prudent to attempt a more general fix that could handle similar inconsistencies elsewhere (if they were to exist) as I believe it would require making unreasonable assumptions and would probably cause more issues than it solves (if indeed it would solve any).

Separately, `ambiguous=True` has been added to the calls to  .floor/.ceil methods. The DST has no affect on what the return is required for (to extract dates, not times) although these methods can raise `pytz.exceptions.AmbiguousTimeError` in some circumstances if `ambiguous` is not defined.