### PR TITLE
Removed News methods from Ticker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pandas>=0.24
 requests-futures>=1.0.0
 selenium>=3.141.0
 tqdm>=4.54.1
+pytest-cov>=4.0.0
+pytest>=7.3.1

--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -95,13 +95,6 @@ def test_multiple_modules_str(ticker):
     assert ticker.get_modules("assetProfile summaryProfile") is not None
 
 
-def test_news(ticker):
-    assert ticker.news() is not None
-
-
-def test_news_start(ticker):
-    assert ticker.news(start="2020-01-01", count=100) is not None
-
 
 def test_all_modules(ticker):
     assert ticker.all_modules is not None

--- a/yahooquery/ticker.py
+++ b/yahooquery/ticker.py
@@ -276,36 +276,6 @@ class Ticker(_YahooFinance):
         """
         return self._quote_summary(["financialData"])
 
-    def news(self, count=25, start=None):
-        """News articles related to given symbol(s)
-
-        Obtain news articles related to a given symbol(s).  Data includes
-        the title of the article, summary, url, author_name, publisher
-
-        Parameters
-        ----------
-        count: int
-            Desired number of news items to return
-        start: str or datetime
-            Date to begin retrieving news items.  If date is a str, utilize
-            the following format: YYYY-MM-DD.
-
-        Notes
-        -----
-        It's recommended to use only one symbol for this property as the data
-        returned does not distinguish between what symbol the news stories
-        belong to
-
-        Returns
-        -------
-        dict
-        """
-        if start:
-            start = _convert_to_timestamp(start)
-        return self._chunk_symbols(
-            "news", params={"count": count, "start": start}, list_result=True
-        )
-
     @property
     def index_trend(self):
         """Index Trend


### PR DESCRIPTION
As referenced in Issue #149 and #44 the news methods are  no longer function since Yahoo has deprecated this API. Therefore, I have removed the relevant methods from the main Ticker class. 