### PR TITLE
History financials (Non-Premium Only)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pandas>=0.24
 requests-futures>=1.0.0
 selenium>=3.141.0
 tqdm>=4.54.1
+pytest-cov>=4.0.0
+pytest>=7.3.1

--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -95,13 +95,6 @@ def test_multiple_modules_str(ticker):
     assert ticker.get_modules("assetProfile summaryProfile") is not None
 
 
-def test_news(ticker):
-    assert ticker.news() is not None
-
-
-def test_news_start(ticker):
-    assert ticker.news(start="2020-01-01", count=100) is not None
-
 
 def test_all_modules(ticker):
     assert ticker.all_modules is not None

--- a/tests/test_ticker.py
+++ b/tests/test_ticker.py
@@ -32,6 +32,13 @@ FINANCIALS = [
     "p_valuation_measures",
 ]
 
+FINANCIALS_HISTORY = [
+    "history_cash_flow",
+    "history_income_statement",
+    "history_balance_sheet"
+]
+
+
 SEPERATE_ENDPOINTS = FINANCIALS + [
     "option_chain",
     "history",
@@ -112,6 +119,20 @@ def test_modules(ticker, module):
 )
 def test_financials(ticker, frequency, module):
     assert getattr(ticker, module)(frequency) is not None
+
+@pytest.mark.parametrize(
+    "module, start, end",
+    [el for el in itertools.product(FINANCIALS_HISTORY,
+    [
+        (start, end)
+        for start, end in zip(
+            [datetime.datetime(2019, 1, 1), "2019-01-01"],
+            ["2019-12-30", datetime.datetime(2019, 12, 30)],
+        )
+    ])]
+)
+def test_history_start_end(ticker, start, end,module):
+    assert getattr(ticker, module)(start=start, end=end) is not None
 
 
 def test_bad_financials_arg():

--- a/yahooquery/ticker.py
+++ b/yahooquery/ticker.py
@@ -685,6 +685,27 @@ class Ticker(_YahooFinance):
         pandas.DataFrame
         """
         return self._financials("cash_flow", frequency, trailing=trailing)
+    def history_cash_flow(self, start, end ,frequency="a", trailing=True):
+        """History Cash Flow
+
+        Retrieves cash flow data between start and end dates.
+
+        Parameters
+        ----------
+        frequency: str, default 'a', optional
+            Specify either annual or quarterly cash flow statement.  Value
+            should be 'a' or 'q'.
+        trailing: bool, default True, optional
+            Specify whether or not you'd like trailing twelve month (TTM)
+            data returned
+
+        Returns
+        -------
+        pandas.DataFrame
+        """
+        period = {"period1": _convert_to_timestamp(start),
+                "period2": _convert_to_timestamp(end)}
+        return self._financials("cash_flow", frequency, trailing=trailing, period=period)
 
     @property
     def company_officers(self):

--- a/yahooquery/ticker.py
+++ b/yahooquery/ticker.py
@@ -457,7 +457,7 @@ class Ticker(_YahooFinance):
         return self._get_data("insights")
 
     def _financials(
-        self, financials_type, frequency=None, premium=False, types=None, trailing=True
+        self, financials_type, frequency=None, premium=False, types=None, trailing=True, period={}
     ):
         try:
             time_dict = self.FUNDAMENTALS_TIME_ARGS[frequency[:1].lower()]
@@ -476,9 +476,10 @@ class Ticker(_YahooFinance):
             ]
         else:
             prefixed_types = ["{}{}".format(prefix, t) for t in types]
-        data = self._get_data(
-            key, {"type": ",".join(prefixed_types)}, **{"list_result": True}
-        )
+        parmas = {"type": ",".join(prefixed_types)}
+        if period:
+            parmas['period1'],parmas['period2'] = period['period1'],period['period2']
+        data = self._get_data(key, parmas, **{"list_result": True})
         dataframes = []
         try:
             for k in data.keys():

--- a/yahooquery/ticker.py
+++ b/yahooquery/ticker.py
@@ -637,6 +637,12 @@ class Ticker(_YahooFinance):
         """
         return self._financials("balance_sheet", frequency, trailing=trailing)
 
+    def history_balance_sheet(self, start, end ,frequency="a", trailing=True):
+
+        period = {"period1": _convert_to_timestamp(start),
+                "period2": _convert_to_timestamp(end)}
+        return self._financials("balance_sheet", frequency, trailing=trailing, period=period)
+    
     def cash_flow(self, frequency="a", trailing=True):
         """Cash Flow
 

--- a/yahooquery/ticker.py
+++ b/yahooquery/ticker.py
@@ -650,10 +650,10 @@ class Ticker(_YahooFinance):
         trailing: bool, default True, optional
             Specify whether or not you'd like trailing twelve month (TTM)
             data returned
-        start: str or datetime.datetime, default None, optional
+        start: str or datetime.datetime
             Specify a starting point to pull data from.  Can be expressed as a
             string with the format YYYY-MM-DD or as a datetime object
-        end: str of datetime.datetime, default None, optional
+        end: str of datetime.datetime
             Specify a ending point to pull data from.  Can be expressed as a
             string with the format YYYY-MM-DD or as a datetime object.
 
@@ -685,6 +685,7 @@ class Ticker(_YahooFinance):
         pandas.DataFrame
         """
         return self._financials("cash_flow", frequency, trailing=trailing)
+    
     def history_cash_flow(self, start, end ,frequency="a", trailing=True):
         """History Cash Flow
 
@@ -698,6 +699,12 @@ class Ticker(_YahooFinance):
         trailing: bool, default True, optional
             Specify whether or not you'd like trailing twelve month (TTM)
             data returned
+        start: str or datetime.datetime
+            Specify a starting point to pull data from.  Can be expressed as a
+            string with the format YYYY-MM-DD or as a datetime object
+        end: str of datetime.datetime
+            Specify a ending point to pull data from.  Can be expressed as a
+            string with the format YYYY-MM-DD or as a datetime object.
 
         Returns
         -------
@@ -783,6 +790,35 @@ class Ticker(_YahooFinance):
         pandas.DataFrame
         """
         return self._financials("income_statement", frequency, trailing=trailing)
+    
+    def history_income_statement(self, start, end ,frequency="a", trailing=True):
+        """History Income Statement
+
+        Retrieves income statement data between start and end dates.
+
+        Parameters
+        ----------
+        frequency: str, default 'a', optional
+            Specify either annual or quarterly income statement.  Value should
+            be 'a' or 'q'.
+        trailing: bool, default True, optional
+            Specify whether or not you'd like trailing twelve month (TTM)
+            data returned
+        start: str or datetime.datetime
+            Specify a starting point to pull data from.  Can be expressed as a
+            string with the format YYYY-MM-DD or as a datetime object
+        end: str of datetime.datetime
+            Specify a ending point to pull data from.  Can be expressed as a
+            string with the format YYYY-MM-DD or as a datetime object.
+        
+        Returns
+        -------
+        pandas.DataFrame
+        """
+        
+        period = {"period1": _convert_to_timestamp(start),
+                "period2": _convert_to_timestamp(end)}
+        return self._financials("income_statement", frequency, trailing=trailing, period=period)
 
     @property
     def insider_holders(self):

--- a/yahooquery/ticker.py
+++ b/yahooquery/ticker.py
@@ -638,7 +638,29 @@ class Ticker(_YahooFinance):
         return self._financials("balance_sheet", frequency, trailing=trailing)
 
     def history_balance_sheet(self, start, end ,frequency="a", trailing=True):
+        """Balance Sheet History
 
+        Retrieves balance sheet data between start and end dates.
+
+        Parameters
+        ----------
+        frequency: str, default 'a', optional
+            Specify either annual or quarterly balance sheet.  Value should
+            be 'a' or 'q'.
+        trailing: bool, default True, optional
+            Specify whether or not you'd like trailing twelve month (TTM)
+            data returned
+        start: str or datetime.datetime, default None, optional
+            Specify a starting point to pull data from.  Can be expressed as a
+            string with the format YYYY-MM-DD or as a datetime object
+        end: str of datetime.datetime, default None, optional
+            Specify a ending point to pull data from.  Can be expressed as a
+            string with the format YYYY-MM-DD or as a datetime object.
+
+        Returns
+        -------
+        pandas.DataFrame
+        """
         period = {"period1": _convert_to_timestamp(start),
                 "period2": _convert_to_timestamp(end)}
         return self._financials("balance_sheet", frequency, trailing=trailing, period=period)

--- a/yahooquery/ticker.py
+++ b/yahooquery/ticker.py
@@ -276,36 +276,6 @@ class Ticker(_YahooFinance):
         """
         return self._quote_summary(["financialData"])
 
-    def news(self, count=25, start=None):
-        """News articles related to given symbol(s)
-
-        Obtain news articles related to a given symbol(s).  Data includes
-        the title of the article, summary, url, author_name, publisher
-
-        Parameters
-        ----------
-        count: int
-            Desired number of news items to return
-        start: str or datetime
-            Date to begin retrieving news items.  If date is a str, utilize
-            the following format: YYYY-MM-DD.
-
-        Notes
-        -----
-        It's recommended to use only one symbol for this property as the data
-        returned does not distinguish between what symbol the news stories
-        belong to
-
-        Returns
-        -------
-        dict
-        """
-        if start:
-            start = _convert_to_timestamp(start)
-        return self._chunk_symbols(
-            "news", params={"count": count, "start": start}, list_result=True
-        )
-
     @property
     def index_trend(self):
         """Index Trend


### PR DESCRIPTION
As requested by #56, I have added financials method which can query the financial data for the ticker between the start and end timestamp. Unfortunately, I don't have yahoo premium therefore could not add and test premium methods with the same feature request. 