### PR TITLE
Fix FutureWarnings for Pandas Compatibility and Chained Assignment

### DIFF
--- a/yahooquery/ticker.py
+++ b/yahooquery/ticker.py
@@ -1330,9 +1330,9 @@ class Ticker(_YahooFinance):
             df = pd.DataFrame(columns=["high", "low", "volume", "open", "close"])
         else:
             if "dividends" in df.columns:
-                df["dividends"].fillna(0, inplace=True)
+                df["dividends"] = df["dividends"].fillna(0)
             if "splits" in df.columns:
-                df["splits"].fillna(0, inplace=True)
+                df["splits"] = df["splits"].fillna(0)
         return df
 
     def _adjust_ohlc(self, df):

--- a/yahooquery/utils/__init__.py
+++ b/yahooquery/utils/__init__.py
@@ -1467,7 +1467,7 @@ def _get_daily_index(data, index_utc, adj_timezone):
         has_live_indice = False
     else:
         last_trade = pd.Timestamp.fromtimestamp(timestamp, tz="UTC")
-        has_live_indice = index_utc[-1] >= last_trade - pd.Timedelta(2, "S")
+        has_live_indice = index_utc[-1] >= last_trade - pd.Timedelta(2, "s")
     if has_live_indice:
         # remove it
         live_indice = index_utc[-1]


### PR DESCRIPTION
#### Changes Made:
1. **Pandas Timedelta Deprecation Warning:**
   - Updated the use of `"S"` to `"s"` in `pd.Timedelta` to conform to the upcoming deprecation in pandas. This change fixes the FutureWarning regarding the deprecation of `'S'` in favor of `'s'` for specifying seconds in `pd.Timedelta`.
   ```python
   # Before:
   has_live_indice = index_utc[-1] >= last_trade - pd.Timedelta(2, "S")
   
   # After:
   has_live_indice = index_utc[-1] >= last_trade - pd.Timedelta(2, "s")
   ```

2. **Chained Assignment Warning:**
   - Altered the approach to setting values in the DataFrame to avoid chained assignment, which is not recommended due to its unclear behavior in certain contexts (operations that behave as if they were on a copy.). This adjustment is in response to pandas' future change in how `inplace=True` will function.
   ```python
   # Before:
   df["dividends"].fillna(0, inplace=True)
...
   df["splits"].fillna(0, inplace=True)
   
   # After:
   df["dividends"] = df["dividends"].fillna(0)
...
   df["splits"] = df["splits"].fillna(0)
   ```