### PR TITLE
Fix pandas 3.0 deprecation warning and chained assignment in yahooquery

### DIFF
--- a/yahooquery/ticker.py
+++ b/yahooquery/ticker.py
@@ -1330,9 +1330,9 @@ class Ticker(_YahooFinance):
             df = pd.DataFrame(columns=["high", "low", "volume", "open", "close"])
         else:
             if "dividends" in df.columns:
-                df["dividends"].fillna(0, inplace=True)
+                df.loc[:, "dividends"] = df["dividends"].fillna(0)
             if "splits" in df.columns:
-                df["splits"].fillna(0, inplace=True)
+                df.loc[:, "splits"] = df["dividends"].fillna(0)
         return df
 
     def _adjust_ohlc(self, df):


### PR DESCRIPTION
Correctly lines 1333:1334 to be compatible with pandas 3 and address futurewarning:

FutureWarning: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method. The behavior will change in pandas 3.0. This inplace method will never work because the intermediate object on which we are setting values always behaves as a copy.

For example, when doing 'df[col].method(value, inplace=True)', try using 'df.method({col: value}, inplace=True)' or df[col] = df[col].method(value) instead, to perform the operation inplace on the original object.