### PR TITLE
Valuation measures added features and new api response

### DIFF
--- a/yahooquery/constants.py
+++ b/yahooquery/constants.py
@@ -587,15 +587,15 @@ FUNDAMENTALS_OPTIONS = {
         "UnrealizedGainLossOnInvestmentSecurities",
     ],
     "valuation": [
-        "ForwardPeRatio",
-        "PsRatio",
-        "PbRatio",
-        "EnterprisesValueEBITDARatio",
-        "EnterprisesValueRevenueRatio",
-        "PeRatio",
         "MarketCap",
         "EnterpriseValue",
+        "PeRatio",
+        "ForwardPeRatio",
         "PegRatio",
+        "PsRatio",
+        "PbRatio",
+        "EnterprisesValueRevenueRatio",
+        "EnterprisesValueEBITDARatio",
     ],
 }
 

--- a/yahooquery/ticker.py
+++ b/yahooquery/ticker.py
@@ -195,7 +195,8 @@ class Ticker(_YahooFinance):
                 One of {} is not a valid value.  Valid values are {}.
             """.format(", ".join(modules), ", ".join(all_modules))
             )
-        return self._quote_summary(modules)
+        data = self._quote_summary(modules)
+        return self._normalize_quote_summary_response(data, "quoteSummary")
 
     @property
     def asset_profile(self):

--- a/yahooquery/ticker.py
+++ b/yahooquery/ticker.py
@@ -208,7 +208,8 @@ class Ticker(_YahooFinance):
         dict
             assetProfile module data
         """
-        return self._quote_summary(["assetProfile"])
+        data = self._quote_summary(["assetProfile"])
+        return self._normalize_quote_summary_response(data, "asset_profile")
 
     @property
     def calendar_events(self):
@@ -222,7 +223,8 @@ class Ticker(_YahooFinance):
         dict
             calendarEvents module data
         """
-        return self._quote_summary(["calendarEvents"])
+        data = self._quote_summary(["calendarEvents"])
+        return self._normalize_quote_summary_response(data, "calendar_events")
 
     @property
     def earnings(self):
@@ -235,7 +237,8 @@ class Ticker(_YahooFinance):
         dict
             earnings module data
         """
-        return self._quote_summary(["earnings"])
+        data = self._quote_summary(["earnings"])
+        return self._normalize_quote_summary_response(data, "earnings")
 
     @property
     def earnings_trend(self):
@@ -249,7 +252,8 @@ class Ticker(_YahooFinance):
         dict
             earningsTrend module data
         """
-        return self._quote_summary(["earningsTrend"])
+        data = self._quote_summary(["earningsTrend"])
+        return self._normalize_quote_summary_response(data, "earnings_trend")
 
     @property
     def esg_scores(self):
@@ -263,7 +267,8 @@ class Ticker(_YahooFinance):
         dict
             esgScores module data
         """
-        return self._quote_summary(["esgScores"])
+        data = self._quote_summary(["esgScores"])
+        return self._normalize_quote_summary_response(data, "esg_scores")
 
     @property
     def financial_data(self):
@@ -276,7 +281,8 @@ class Ticker(_YahooFinance):
         dict
             financialData module data
         """
-        return self._quote_summary(["financialData"])
+        data = self._quote_summary(["financialData"])
+        return self._normalize_quote_summary_response(data, "financial_data")
 
     def news(self, count=25, start=None):
         """News articles related to given symbol(s)
@@ -320,7 +326,8 @@ class Ticker(_YahooFinance):
         dict
             indexTrend module data
         """
-        return self._quote_summary(["indexTrend"])
+        data = self._quote_summary(["indexTrend"])
+        return self._normalize_quote_summary_response(data, "index_trend")
 
     @property
     def industry_trend(self):
@@ -333,7 +340,8 @@ class Ticker(_YahooFinance):
         dict
             industryTrend module data
         """
-        return self._quote_summary(["industryTrend"])
+        data = self._quote_summary(["industryTrend"])
+        return self._normalize_quote_summary_response(data, "industry_trend")
 
     @property
     def key_stats(self):
@@ -346,7 +354,8 @@ class Ticker(_YahooFinance):
         dict
             defaultKeyStatistics module data
         """
-        return self._quote_summary(["defaultKeyStatistics"])
+        data = self._quote_summary(["defaultKeyStatistics"])
+        return self._normalize_quote_summary_response(data, "key_stats")
 
     @property
     def major_holders(self):
@@ -360,7 +369,8 @@ class Ticker(_YahooFinance):
         dict
             majorHoldersBreakdown module data
         """
-        return self._quote_summary(["majorHoldersBreakdown"])
+        data = self._quote_summary(["majorHoldersBreakdown"])
+        return self._normalize_quote_summary_response(data, "major_holders")
 
     @property
     def page_views(self):
@@ -373,7 +383,8 @@ class Ticker(_YahooFinance):
         dict
             pageViews module data
         """
-        return self._quote_summary(["pageViews"])
+        data = self._quote_summary(["pageViews"])
+        return self._normalize_quote_summary_response(data, "page_views")
 
     @property
     def price(self):
@@ -387,7 +398,8 @@ class Ticker(_YahooFinance):
         dict
             price module data
         """
-        return self._quote_summary(["price"])
+        data = self._quote_summary(["price"])
+        return self._normalize_quote_summary_response(data, "price")
 
     @property
     def quote_type(self):
@@ -446,7 +458,8 @@ class Ticker(_YahooFinance):
         dict
             netSharePurchaseActivity module data
         """
-        return self._quote_summary(["netSharePurchaseActivity"])
+        data = self._quote_summary(["netSharePurchaseActivity"])
+        return self._normalize_quote_summary_response(data, "share_purchase_activity")
 
     @property
     def summary_detail(self):
@@ -459,7 +472,8 @@ class Ticker(_YahooFinance):
         dict
             summaryDetail module data
         """
-        return self._quote_summary(["summaryDetail"])
+        data = self._quote_summary(["summaryDetail"])
+        return self._normalize_quote_summary_response(data, "summary_detail")
 
     @property
     def summary_profile(self):
@@ -472,7 +486,8 @@ class Ticker(_YahooFinance):
         dict
             summaryProfile module data
         """
-        return self._quote_summary(["summaryProfile"])
+        data = self._quote_summary(["summaryProfile"])
+        return self._normalize_quote_summary_response(data, "summary_profile")
 
     @property
     def technical_insights(self):


### PR DESCRIPTION
The valuation measures API now includes a current option; it is no longer limited to quarterly statistics. This means a user can get more up-to-date information from the trailing twelve months. I added this functionality to the library and ways to toggle quarterly and yearly options, along with trailing options.

Original response for AAPL:
type: <class 'pandas.core.frame.DataFrame'>
columns: Index(['asOfDate', 'periodType', 'EnterpriseValue',
       'EnterprisesValueEBITDARatio', 'EnterprisesValueRevenueRatio',
       'ForwardPeRatio', 'MarketCap', 'PbRatio', 'PeRatio', 'PegRatio',
       'PsRatio'],
      dtype='object')
         asOfDate periodType  EnterpriseValue  EnterprisesValueEBITDARatio  EnterprisesValueRevenueRatio  ForwardPeRatio     MarketCap    PbRatio    PeRatio  PegRatio   PsRatio
symbol
AAPL   2024-06-10        TTM     2.998758e+12                      22.5476                        7.8579         26.2467  2.961318e+12  39.913172  30.034215    2.0439  7.905597
AAPL   2024-07-12        TTM     3.573939e+12                      26.8723                        9.3651         31.1526  3.536499e+12  47.665570  35.867807    2.4183  9.441114
AAPL   2024-09-19        TTM     3.519730e+12                      26.0433                        9.1279         30.1205  3.480227e+12  52.171058  34.840183    2.1968  9.210233
AAPL   2024-09-30         3M     3.561714e+12                      26.3540                        9.2367         30.6748  3.522211e+12  52.800431  35.464231    2.2362  9.375205
AAPL   2024-12-31         3M     3.807958e+12                      28.2781                        9.7382         33.6700  3.766500e+12  66.136960  41.187500    2.2897  9.867391

New response for AAPL:
type: <class 'pandas.core.frame.DataFrame'>
columns: Index(['asOfDate', 'periodType', 'EnterpriseValue',
       'EnterprisesValueEBITDARatio', 'EnterprisesValueRevenueRatio',
       'ForwardPeRatio', 'MarketCap', 'PbRatio', 'PeRatio', 'PegRatio',
       'PsRatio'],
      dtype='object')
         asOfDate periodType  EnterpriseValue  EnterprisesValueEBITDARatio  EnterprisesValueRevenueRatio  ForwardPeRatio     MarketCap    PbRatio    PeRatio  PegRatio   PsRatio
symbol
AAPL   2025-08-20        TTM     3.400403e+12                          NaN                        8.3216             NaN           NaN  50.950578        NaN    2.0401  8.351520
AAPL   2025-09-30        12M     3.808041e+12                      26.8747                        9.3192         31.6456  3.761715e+12  57.142871  38.638847    2.4377  9.409086
AAPL   2025-10-02        TTM              NaN                      27.2572                        9.4518         32.0513           NaN  57.966117  39.018209    2.4662  9.501466
AAPL   2025-10-03        TTM     3.862235e+12                          NaN                           NaN             NaN  3.815909e+12        NaN        NaN       NaN       NaN
AAPL   2025-11-19        TTM     4.012297e+12                      27.7192                        9.6412         32.3625  3.968337e+12  53.820370  36.000000    2.7178  9.682939

As you can see, the original function was severely out of date.